### PR TITLE
fix(trace): use correct 2012-02-06 Dick-Nielsen regime cutoff

### DIFF
--- a/tests/test_download_data_wrds_trace_enhanced.py
+++ b/tests/test_download_data_wrds_trace_enhanced.py
@@ -14,6 +14,7 @@ sys.path.insert(
 from tidyfinance.data_download import (  # noqa: E402
     _download_data_wrds_trace_enhanced,
 )
+from tidyfinance.utilities import process_trace_data  # noqa: E402
 
 
 def test_download_data_wrds_trace_enhanced_validates_cusips():
@@ -101,6 +102,57 @@ def test_download_data_wrds_trace_enhanced_cleans_trace_data():
     assert expected_vols.issubset(actual_vols) or actual_vols.issubset(
         expected_vols
     )
+
+
+def test_process_trace_data_uses_2012_02_06_regime_cutoff():
+    """Trades reported in the Feb 6 - Jun 2, 2012 window are cleaned under
+    the post-2012 regime.
+
+    The Dick-Nielsen (2014) regime cutoff is 2012-02-06. A transposed cutoff
+    (2012-06-02) would misclassify the entire Feb 6 - Jun 2, 2012 window as
+    pre-2012, where the post-2012 cancellation logic (trc_st == 'X') is not
+    applied. This is a regression test for that transposition.
+    """
+    d = pd.Timestamp("2012-04-01")  # inside [2012-02-06, 2012-06-02)
+
+    def row(msg, vol, status):
+        return {
+            "cusip_id": "00101JAH9",
+            "msg_seq_nb": msg,
+            "orig_msg_seq_nb": None,
+            "entrd_vol_qt": vol,
+            "rptd_pr": 99,
+            "yld_pt": 4,
+            "rpt_side_cd": "S",
+            "cntra_mp_id": "C",
+            "trd_exctn_dt": d,
+            "trd_exctn_tm": "10:00:00",
+            "trd_rpt_dt": d,
+            "trd_rpt_tm": "10:01:00",
+            "trc_st": status,
+            "asof_cd": "",
+            "wis_fl": "N",
+            "days_to_sttl_ct": 1,
+            "stlmnt_dt": d + pd.Timedelta(days=1),
+            "spcl_trd_fl": "",
+        }
+
+    trace = pd.DataFrame(
+        [
+            row(10, 100, "T"),  # trade, cancelled by the X below (post regime)
+            row(10, 100, "X"),  # post-2012 cancellation of msg 10
+            row(11, 200, "T"),  # untouched control trade
+        ]
+    )
+
+    out = process_trace_data(trace)
+    vols = set(out["entrd_vol_qt"].tolist())
+
+    # Post-2012 regime: the X cancels the trade -> 100 removed, 200 kept.
+    # With the transposed cutoff this window was treated as pre-2012, the
+    # X cancellation was ignored, and volume 100 survived.
+    assert 200 in vols
+    assert 100 not in vols
 
 
 if __name__ == "__main__":

--- a/tidyfinance/utilities.py
+++ b/tidyfinance/utilities.py
@@ -288,17 +288,25 @@ def process_trace_data(trace_all: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
         pd.DataFrame: The cleaned and processed TRACE data.
+
+    Notes
+    -----
+    Trades are cleaned under two regimes split by the date the enhanced
+    TRACE message-status format changed (``2012-02-06``; see Dick-Nielsen,
+    2014). Trades reported on or after this date use the post-2012 logic and
+    earlier trades the pre-2012 logic. This matches the cutoff used by the
+    R edition (``download_data_wrds_trace_enhanced`` in r-tidyfinance).
     """
-    # Post 2012-06-02
+    # Post 2012-02-06
     ## Trades (trc_st = T) and correction (trc_st = R)
     trace_post_TR = trace_all.query("trc_st in ['T', 'R']").query(
-        "trd_rpt_dt >= '2012-06-02'"
+        "trd_rpt_dt >= '2012-02-06'"
     )
 
     # Cancellations (trc_st = X) and correction cancellations (trc_st = C)
     trace_post_XC = (
         trace_all.query("trc_st in ['X', 'C']")
-        .query("trd_rpt_dt >= '2012-06-02'")
+        .query("trd_rpt_dt >= '2012-02-06'")
         .get(
             [
                 "cusip_id",
@@ -324,7 +332,7 @@ def process_trace_data(trace_all: pd.DataFrame) -> pd.DataFrame:
     # Reversals (trc_st = Y)
     trace_post_Y = (
         trace_all.query("trc_st == 'Y'")
-        .query("trd_rpt_dt >= '2012-06-02'")
+        .query("trd_rpt_dt >= '2012-02-06'")
         .get(
             [
                 "cusip_id",
@@ -349,15 +357,15 @@ def process_trace_data(trace_all: pd.DataFrame) -> pd.DataFrame:
         .drop(columns="drop")
     )
 
-    # Enhanced TRACE: Pre 06-02-2012
-    # Pre 06-02-12
+    # Enhanced TRACE: Pre 2012-02-06
+    # Pre 2012-02-06
     ## Trades (trc_st = T)
-    trace_pre_T = trace_all.query("trd_rpt_dt < '2012-06-02'")
+    trace_pre_T = trace_all.query("trd_rpt_dt < '2012-02-06'")
 
     # Cancellations (trc_st = C)
     trace_pre_C = (
         trace_all.query("trc_st == 'C'")
-        .query("trd_rpt_dt < '2012-06-02'")
+        .query("trd_rpt_dt < '2012-02-06'")
         .get(
             [
                 "cusip_id",
@@ -384,7 +392,7 @@ def process_trace_data(trace_all: pd.DataFrame) -> pd.DataFrame:
 
     # Corrections (trc_st = W)
     trace_pre_W = trace_all.query("trc_st == 'W'").query(
-        "trd_rpt_dt < '2012-06-02'"
+        "trd_rpt_dt < '2012-02-06'"
     )
 
     # Implement corrections in a loop


### PR DESCRIPTION
## Summary

`process_trace_data()` in [`tidyfinance/utilities.py`](tidyfinance/utilities.py) used **`'2012-06-02'`** (June 2, 2012) as the pre/post Dick-Nielsen regime cutoff on `trd_rpt_dt`. The correct cutoff is **`'2012-02-06'`** (February 6, 2012) — the date the enhanced TRACE message-status format changed (Dick-Nielsen 2014). The month and day were transposed.

The R edition (`download_data_wrds_trace_enhanced()` in r-tidyfinance) uses `2012-02-06` at all corresponding filters, so this aligns the two editions.

## What changed

- Replaced all **6** occurrences of `'2012-06-02'` → `'2012-02-06'` in `process_trace_data` (3 post-regime `>=` filters, 3 pre-regime `<` filters).
- Corrected the misleading inline comments (`# Post 2012-06-02`, `# Pre 06-02-12`, …).
- Added a `Notes` section to the docstring explaining the cutoff and citing Dick-Nielsen (2014).
- Added a regression test (`test_process_trace_data_uses_2012_02_06_regime_cutoff`) that exercises a trade reported `2012-04-01` (inside the previously-misclassified Feb 6 – Jun 2, 2012 window) with a post-2012 `X` cancellation.

## Impact

A month/day transposition. Samples lying entirely after June 2012 are unaffected (every trade is "post" under either date). Any sample spanning **Feb 6 – Jun 2, 2012** had trades in that window cleaned under the wrong regime (the cancellation/correction/reversal `trc_st` logic differs pre vs post), producing incorrect output.

## Verification

- The new regression test **fails** on the old date (volume 100 survives because the `X` cancellation is ignored under the pre-2012 regime) and **passes** on the corrected date.
- Full suite: **244 passed** locally (`uv run pytest`).
- Verified against `r-tidyfinance/R/download_data_wrds_trace_enhanced.R` (uses `as.Date("2012-02-06")`).

## Related (out of scope, separate repos)

The same transposed date appears in the companion gist `clean_enhanced_trace` and the tidy-finance/website appendix `python/clean-enhanced-trace-with-python.qmd`; those should be fixed separately for consistency.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)