### PR TITLE
fix(crsp): order listing_age before mktcap to match r-tidyfinance

### DIFF
--- a/tests/test_download_data_wrds_crsp.py
+++ b/tests/test_download_data_wrds_crsp.py
@@ -173,6 +173,16 @@ def test_monthly_crsp_v2_is_processed():
     assert isinstance(out, pd.DataFrame)
     assert "mthvol" in out.columns
     assert "mktcap" in out.columns
+    # Column order must match r-tidyfinance's download_data_wrds_crsp (v2):
+    # ..., siccd, <additional_columns>, listing_age, mktcap, mktcap_lag, ...
+    # In particular listing_age precedes mktcap (regression test for the
+    # swapped columns 9-10 reported in issue #36).
+    assert list(out.columns) == [
+        "permno", "date", "calculation_date", "ret", "shrout", "prc",
+        "primaryexch", "siccd", "mthvol", "listing_age", "mktcap",
+        "mktcap_lag", "exchange", "industry", "ret_excess",
+    ]
+    assert out.columns.get_loc("listing_age") < out.columns.get_loc("mktcap")
 
 
 def test_daily_crsp_v2_validates_and_adjusts_volume():

--- a/tidyfinance/data_download.py
+++ b/tidyfinance/data_download.py
@@ -1444,8 +1444,9 @@ def _download_data_wrds_crsp(
                         },
                     )
                     .assign(shrout=lambda x: x["shrout"] * 1000)
-                    .assign(mktcap=lambda x: x["shrout"] * x["prc"] / 1000000)
-                    .assign(mktcap=lambda x: x["mktcap"].replace(0, np.nan))
+                    # listing_age is assigned before mktcap so the output
+                    # column order matches r-tidyfinance (..., siccd,
+                    # listing_age, mktcap, mktcap_lag, ...).
                     .assign(
                         listing_age=lambda df: (
                             (df["date"].dt.year - df["first_crsp_date"].dt.year)
@@ -1459,6 +1460,8 @@ def _download_data_wrds_crsp(
                             ).astype(int)
                         ).clip(lower=0)
                     )
+                    .assign(mktcap=lambda x: x["shrout"] * x["prc"] / 1000000)
+                    .assign(mktcap=lambda x: x["mktcap"].replace(0, np.nan))
                     .drop(columns=["first_crsp_date"])
                 )
 


### PR DESCRIPTION
## Summary

For `crsp_monthly` (v2), the Python `download_data_wrds_crsp` output had columns 9 and 10 — `listing_age` and `mktcap` — **swapped** relative to r-tidyfinance. Values were identical; only the column order differed (reported in #36).

The cause: `mktcap` was assigned before `listing_age`, so `mktcap` landed in column 9 and `listing_age` in column 10. r-tidyfinance's [`download_data_wrds_crsp.R`](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_crsp.R) v2 path mutates `listing_age` first, giving `…, siccd, <additional_columns>, listing_age, mktcap, mktcap_lag, exchange, industry, ret_excess`.

## What changed

- Assign `listing_age` before `mktcap` in the `crsp_monthly` v2 path. The two computations are independent (`listing_age` ← `date`/`first_crsp_date`; `mktcap` ← `shrout`/`prc`), and `mktcap_lag` is still derived after `mktcap`, so the change is purely positional — **no values change**.
- Extended `test_monthly_crsp_v2_is_processed` to assert the full canonical column order and that `listing_age` precedes `mktcap`.

## Verification

- Python output column order now equals R's exactly, including additional-column placement (verified against `r-tidyfinance/R/download_data_wrds_crsp.R` lines 338–430, and reproduced with the existing mock + `additional_columns=["mthvol"]`).
- The new assertion **fails** on the old ordering (`At index 9 diff: 'mktcap' != 'listing_age'`) and **passes** with the fix.
- Full suite: **243 passed** locally (`uv run pytest`).

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)