### PR TITLE
docs(changelog): note altprc → prc rename for crsp_monthly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,7 @@
 ## v0.2.6 (2026-04-02)
 
 - Added support for Hugging Face datasets via `domain="tidyfinance"`, including `high_frequency_sp500` and `factor_library`
+
+## Unreleased
+
+- **Breaking (CRSP):** the monthly CRSP price column returned by `download_data(domain="wrds", dataset="crsp_monthly")` is now named `prc` (was `altprc`), aligning with r-tidyfinance and both book editions. The value is unchanged — it is `mthprc` from the CRSP v2 monthly stock file; `altprc` was the legacy (v1) column name and was semantically stale for v2 downloads. Update any downstream code that referenced `altprc` (including the dependent `mktcap` computation).


### PR DESCRIPTION
## Summary

Adds the CHANGELOG deprecation note requested in #30 for the `altprc` → `prc` rename of the monthly CRSP price column.

The **code** rename already landed on `main` in commit `db1ad68` — `download_data(domain="wrds", dataset="crsp_monthly")` now returns `prc` (`msf.mthprc AS prc`, and `mktcap = shrout * prc / 1e6`), and `git grep altprc` returns nothing. This PR adds the remaining outstanding item from the issue: a note so downstream users who referenced `altprc` are informed.

## What changed

- Added an `## Unreleased` section to [`CHANGELOG.md`](CHANGELOG.md) (at the bottom, following the file's oldest-at-top/newest-at-bottom ordering) documenting the rename as a breaking change, noting the value is unchanged (`mthprc` from the CRSP v2 monthly file) and that `altprc` was the stale legacy v1 name.

No code change.

## Verification

- All factual claims verified against the code (`data_download.py:1409`, `:1447`) and against `r-tidyfinance/R/download_data_wrds_crsp.R` (`prc = mthprc`, `mktcap = shrout*prc/10^6`).
- Repo-wide grep confirms no `altprc` references remain in any source/test/doc file.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)