### PR TITLE
Align tests with companion R package; mock all network access

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -189,6 +189,90 @@ def test_estimate_rolling_betas_min_obs(sample_data: pd.DataFrame) -> None:
     )
 
 
+def test_estimate_betas_min_obs_non_positive_raises(
+    sample_data: pd.DataFrame,
+) -> None:
+    """min_obs <= 0 raises a ValueError."""
+    for bad in (0, -5):
+        with pytest.raises(ValueError, match="min_obs must be a positive"):
+            estimate_betas(
+                sample_data, "ret_excess ~ mkt_excess", 30, min_obs=bad
+            )
+
+
+def test_estimate_betas_default_min_obs_is_80_percent(
+    sample_data: pd.DataFrame,
+) -> None:
+    """min_obs defaults to 80% of lookback when not provided."""
+    lookback = 30
+    default = estimate_betas(sample_data, "ret_excess ~ mkt_excess", lookback)
+    explicit = estimate_betas(
+        sample_data,
+        "ret_excess ~ mkt_excess",
+        lookback,
+        min_obs=int(lookback * 0.8),
+    )
+    pd.testing.assert_frame_equal(default, explicit)
+
+
+def test_estimate_betas_without_intercept_omits_intercept_column(
+    sample_data: pd.DataFrame,
+) -> None:
+    """A '- 1' formula omits the Intercept column."""
+    result = estimate_betas(sample_data, "ret_excess ~ mkt_excess - 1", 30)
+    assert "Intercept" not in result.columns
+    assert "mkt_excess" in result.columns
+
+
+def test_estimate_betas_match_per_window_ols(
+    sample_data: pd.DataFrame,
+) -> None:
+    """Estimated betas match a per-window OLS fit."""
+    lookback = 30
+    result = estimate_betas(sample_data, "ret_excess ~ mkt_excess", lookback)
+
+    group = (
+        sample_data[sample_data["permno"] == 1]
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+    i = 50
+    window = group.iloc[i - lookback + 1 : i + 1]
+    design = np.column_stack(
+        [np.ones(len(window)), window["mkt_excess"].values]
+    )
+    expected = np.linalg.lstsq(design, window["ret_excess"].values, rcond=None)[
+        0
+    ]
+
+    row = result[
+        (result["permno"] == 1) & (result["date"] == group.loc[i, "date"])
+    ]
+    np.testing.assert_allclose(
+        row[["Intercept", "mkt_excess"]].values[0], expected, rtol=1e-8
+    )
+
+
+def test_estimate_betas_custom_id_column(
+    sample_data: pd.DataFrame,
+) -> None:
+    """A non-default stock identifier column is honored."""
+    renamed = sample_data.rename(columns={"permno": "gvkey"})
+    result = estimate_betas(
+        renamed, "ret_excess ~ mkt_excess", 30, id_col="gvkey"
+    )
+    assert "gvkey" in result.columns
+    assert "permno" not in result.columns
+
+
+def test_estimate_betas_invalid_formula_raises(
+    sample_data: pd.DataFrame,
+) -> None:
+    """A formula without '~' raises a ValueError."""
+    with pytest.raises(ValueError, match="must contain '~'"):
+        estimate_betas(sample_data, "ret_excess mkt_excess", 30)
+
+
 def sample_data_fmb() -> pd.DataFrame:
     np.random.seed(42)
     dates = pd.date_range(start="2020-01-01", periods=12, freq="ME")
@@ -223,6 +307,30 @@ def test_estimate_fama_macbeth_vcov(sample_data: pd.DataFrame) -> None:
     assert "t_statistic" in result.columns, (
         "Output should include t-statistics based on vcov choice"
     )
+
+
+def test_estimate_fama_macbeth_invalid_vcov_raises() -> None:
+    """An unsupported vcov option raises a ValueError."""
+    with pytest.raises(ValueError, match="vcov must be either"):
+        estimate_fama_macbeth(
+            sample_data_fmb(),
+            "ret_excess ~ beta + bm + log_mktcap",
+            vcov="bogus",
+        )
+
+
+def test_estimate_fama_macbeth_missing_date_column_raises() -> None:
+    """A missing date column raises a ValueError."""
+    data = sample_data_fmb().drop(columns="date")
+    with pytest.raises(ValueError, match="must contain a date column"):
+        estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
+
+
+def test_estimate_fama_macbeth_n_equals_number_of_periods() -> None:
+    """The reported 'n' equals the number of distinct periods."""
+    data = sample_data_fmb()
+    result = estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
+    assert (result["n"] == data["date"].nunique()).all()
 
 
 # Fixed series with reference values computed in R via
@@ -399,6 +507,14 @@ def test_create_summary_statistics_rejects_strings() -> None:
     df = pd.DataFrame({"name": ["A", "B", "C"], "x": [1, 2, 3]})
     with pytest.raises(ValueError, match="not numeric or boolean"):
         create_summary_statistics(df, ["name", "x"])
+
+
+def test_create_summary_statistics_handles_na() -> None:
+    """NA values are dropped before statistics are computed."""
+    df = pd.DataFrame({"x": [1.0, 2.0, np.nan, 4.0]})
+    result = create_summary_statistics(df, ["x"])
+    assert result["count"].iloc[0] == 3
+    assert result["mean"].iloc[0] == pytest.approx((1.0 + 2.0 + 4.0) / 3)
 
 
 def sample_data_ls() -> pd.DataFrame:

--- a/tests/test_disconnect_connection.py
+++ b/tests/test_disconnect_connection.py
@@ -1,0 +1,36 @@
+"""Tests for disconnect_connection."""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.utilities import disconnect_connection  # noqa: E402
+
+
+def test_returns_true_on_successful_disconnect():
+    """Test disconnect_connection returns True on success."""
+    connection = MagicMock()
+    result = disconnect_connection(connection)
+
+    assert result is True
+    connection.close.assert_called_once()
+
+
+def test_returns_false_when_close_raises():
+    """Test disconnect_connection returns False when close fails."""
+    connection = MagicMock()
+    connection.close.side_effect = Exception("disconnection failed")
+
+    result = disconnect_connection(connection)
+
+    assert result is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_download_data_factors.py
+++ b/tests/test_download_data_factors.py
@@ -1,8 +1,10 @@
 """Tests for download_data_factors_ff and download_data_factors_q."""
 
+import io
 import os
 import sys
-from unittest.mock import patch
+import zipfile
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -14,6 +16,7 @@ sys.path.insert(
 from tidyfinance.data_download import (
     _download_data_factors_ff,
     _download_data_factors_q,
+    _famafrench_downloader,
 )  # noqa: E402
 from tidyfinance.supported_datasets import (
     _check_supported_dataset_ff,
@@ -402,6 +405,71 @@ def test_download_data_factors_ff_does_not_rescale_breakpoints():
     ):
         result = _download_data_factors_ff("ME Breakpoints")
     assert list(result["v2"]) == [488, 492]
+
+
+# %% _famafrench_downloader
+
+
+def _make_french_zip(table_body):
+    """Build an in-memory Kenneth French style ZIP from a CSV body.
+
+    A leading documentation chunk is prepended so the parser has to
+    skip it and keep only the first data table.
+    """
+    header = "This file was created for testing tidyfinance. " * 3
+    data_raw = header + "\r\n\r\n" + table_body
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("data.csv", data_raw.encode("latin1"))
+    response = MagicMock()
+    response.content = buffer.getvalue()
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def test_famafrench_downloader_parses_first_table():
+    """Test _famafrench_downloader parses the first table in the archive."""
+    rows = "\r\n".join(
+        f"{y}{m:02d},1.0,0.1" for y in range(2000, 2021) for m in range(1, 13)
+    )
+    response = _make_french_zip(",Mkt-RF,RF\r\n" + rows)
+
+    with patch("tidyfinance.data_download.requests.get", return_value=response):
+        result = _famafrench_downloader("ftp/Some_File_CSV.zip")
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["Mkt-RF", "RF"]
+    assert result.index.name == "date"
+    assert len(result) == 252
+
+
+def test_famafrench_downloader_applies_date_filter():
+    """Test _famafrench_downloader filters the parsed table by date."""
+    rows = "\r\n".join(
+        f"{y}{m:02d},1.0,0.1" for y in range(2000, 2021) for m in range(1, 13)
+    )
+    response = _make_french_zip(",Mkt-RF,RF\r\n" + rows)
+
+    with patch("tidyfinance.data_download.requests.get", return_value=response):
+        result = _famafrench_downloader(
+            "ftp/Some_File_CSV.zip",
+            start_date="2010-01-01",
+            end_date="2010-12-31",
+        )
+
+    assert len(result) == 12
+    assert result.index.min() >= pd.Timestamp("2010-01-01")
+    assert result.index.max() <= pd.Timestamp("2010-12-31")
+
+
+def test_famafrench_downloader_propagates_download_error():
+    """Test _famafrench_downloader propagates HTTP download errors."""
+    response = MagicMock()
+    response.raise_for_status.side_effect = Exception("404 error")
+
+    with patch("tidyfinance.data_download.requests.get", return_value=response):
+        with pytest.raises(Exception, match="404 error"):
+            _famafrench_downloader("ftp/Missing_CSV.zip")
 
 
 if __name__ == "__main__":

--- a/tests/test_get_wrds_connection.py
+++ b/tests/test_get_wrds_connection.py
@@ -1,0 +1,86 @@
+"""Tests for get_wrds_connection and load_wrds_credentials."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.utilities import (  # noqa: E402
+    get_wrds_connection,
+    load_wrds_credentials,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_dotenv(monkeypatch):
+    """Prevent load_dotenv from reading a local .env during tests."""
+    monkeypatch.setattr(
+        "tidyfinance.utilities.load_dotenv", lambda *a, **k: None
+    )
+
+
+def test_load_wrds_credentials_returns_tuple_when_set(monkeypatch):
+    """Test load_wrds_credentials returns the credentials when set."""
+    monkeypatch.setenv("WRDS_USER", "user")
+    monkeypatch.setenv("WRDS_PASSWORD", "pass")
+
+    assert load_wrds_credentials() == ("user", "pass")
+
+
+def test_load_wrds_credentials_raises_when_missing(monkeypatch):
+    """Test load_wrds_credentials raises when credentials are missing."""
+    monkeypatch.delenv("WRDS_USER", raising=False)
+    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="WRDS credentials not found"):
+        load_wrds_credentials()
+
+
+def test_get_wrds_connection_raises_when_credentials_missing(monkeypatch):
+    """Test get_wrds_connection raises when credentials are missing."""
+    monkeypatch.delenv("WRDS_USER", raising=False)
+    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+
+    with pytest.raises(ValueError, match="WRDS credentials not found"):
+        get_wrds_connection()
+
+
+def test_get_wrds_connection_returns_connection_when_set(monkeypatch):
+    """Test get_wrds_connection returns a connection when credentials set."""
+    monkeypatch.setenv("WRDS_USER", "user")
+    monkeypatch.setenv("WRDS_PASSWORD", "pass")
+
+    fake_connection = MagicMock(name="connection")
+    fake_engine = MagicMock(name="engine")
+    fake_engine.connect.return_value = fake_connection
+
+    with patch(
+        "tidyfinance.utilities.create_engine", return_value=fake_engine
+    ) as mock_create_engine:
+        result = get_wrds_connection()
+
+    assert result is fake_connection
+    mock_create_engine.assert_called_once()
+    fake_engine.connect.assert_called_once()
+
+
+def test_get_wrds_connection_propagates_connect_errors(monkeypatch):
+    """Test get_wrds_connection propagates errors from connecting."""
+    monkeypatch.setenv("WRDS_USER", "user")
+    monkeypatch.setenv("WRDS_PASSWORD", "pass")
+
+    fake_engine = MagicMock(name="engine")
+    fake_engine.connect.side_effect = Exception("connection refused")
+
+    with patch("tidyfinance.utilities.create_engine", return_value=fake_engine):
+        with pytest.raises(Exception, match="connection refused"):
+            get_wrds_connection()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_list_tidy_finance_chapters.py
+++ b/tests/test_list_tidy_finance_chapters.py
@@ -1,0 +1,30 @@
+"""Tests for list_tidy_finance_chapters."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.utilities import list_tidy_finance_chapters  # noqa: E402
+
+
+def test_returns_list_of_chapter_names():
+    """Test returns the expected list of chapter names."""
+    result = list_tidy_finance_chapters()
+    assert isinstance(result, list)
+    assert len(result) > 0
+    assert all(isinstance(chapter, str) for chapter in result)
+
+
+def test_includes_known_chapter():
+    """Test that a known chapter slug is present."""
+    result = list_tidy_finance_chapters()
+    assert "beta-estimation" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_open_tidy_finance_website.py
+++ b/tests/test_open_tidy_finance_website.py
@@ -1,0 +1,52 @@
+"""Tests for open_tidy_finance_website."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.utilities import open_tidy_finance_website  # noqa: E402
+
+BASE_URL = "https://www.tidy-finance.org/python/"
+
+
+def test_opens_base_url_when_chapter_is_none():
+    """Test opens base URL and returns None when chapter is None."""
+    with patch("tidyfinance.utilities.webbrowser.open") as mock_open:
+        result = open_tidy_finance_website()
+
+    assert result is None
+    mock_open.assert_called_once_with(BASE_URL)
+
+
+def test_opens_chapter_url_when_chapter_exists():
+    """Test opens chapter URL when chapter exists in the chapter list."""
+    with patch(
+        "tidyfinance.utilities.list_tidy_finance_chapters",
+        return_value=["beta-estimation"],
+    ):
+        with patch("tidyfinance.utilities.webbrowser.open") as mock_open:
+            open_tidy_finance_website("beta-estimation")
+
+    mock_open.assert_called_once_with(f"{BASE_URL}beta-estimation.html")
+
+
+def test_falls_back_to_base_url_for_unknown_chapter():
+    """Test falls back to base URL when chapter is not in the list."""
+    with patch(
+        "tidyfinance.utilities.list_tidy_finance_chapters",
+        return_value=["beta-estimation"],
+    ):
+        with patch("tidyfinance.utilities.webbrowser.open") as mock_open:
+            open_tidy_finance_website("unknown-chapter")
+
+    mock_open.assert_called_once_with(BASE_URL)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

Aligns the Python test suite with the companion R package's tests (kept locally in `r-tests/`), focusing on public-API behavior and real coverage gaps. **All tests that load data from online sources are mocked** — the full suite passes with network access blocked.

- **564 → 589 tests** (+25), all green with `socket.connect` patched to raise.

## New per-function test files (previously untested public functions)

- `list_tidy_finance_chapters`
- `open_tidy_finance_website` (mocks `webbrowser.open`)
- `disconnect_connection`
- `get_wrds_connection` / `load_wrds_credentials` (mocks `create_engine` + env vars)

## Coverage gaps filled in existing files

- **`_famafrench_downloader`** — direct ZIP-parse, date-filter, and HTTP-error tests against an in-memory ZIP (the parser was previously fully mocked away)
- **`estimate_betas`** — `min_obs<=0` raises, default `min_obs`, no-intercept model, match per-window OLS, custom `id_col`, invalid formula (R had 16 cases vs Python's 2)
- **`estimate_fama_macbeth`** — invalid `vcov` raises, missing date column raises, `n` equals number of periods
- **`create_summary_statistics`** — NA handling

## Notes

- R-specific assertions that don't translate to Python (integer-vs-numeric vector types, NA-vs-NULL, "returns object of class X" for plain dicts, R's string `lookback` parsing where Python takes an integer) were intentionally not ported.
- Existing aggregated `test_core.py` / `test_internal.py` were kept as-is (cases added in place) rather than split into per-function files.
- Out of scope: three pre-existing ruff lint issues in untouched test files (`test_backend.py` F811 duplicate test, two unused imports) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)