### PR TITLE
Cast polars date columns to Date and apply ruff formatting

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -72,6 +72,20 @@ def test_convert_output_preserves_named_index_as_column():
     df.index.name = "date"
     out = _convert_output(df)
     assert "date" in out.columns
+    assert out.schema["date"] == pl.Date
+
+
+def test_convert_output_casts_date_column_to_polars_date():
+    tf.set_backend("polars")
+    df = pd.DataFrame(
+        {"date": pd.to_datetime(["2020-01-31", "2020-02-29"]), "v": [1.0, 2.0]}
+    )
+    out = _convert_output(df)
+    assert out.schema["date"] == pl.Date
+    assert out["date"].dt.strftime("%Y-%m-%d").to_list() == [
+        "2020-01-31",
+        "2020-02-29",
+    ]
 
 
 def test_convert_output_drops_default_rangeindex():

--- a/tidyfinance/_internal.py
+++ b/tidyfinance/_internal.py
@@ -72,9 +72,7 @@ def _validate_dates(
             )
             return start_date.date(), end_date.date()
         else:
-            print("No start_date or end_date provided. "
-                  "Returning the full dataset."
-                  )
+            print("No start_date or end_date provided. " "Returning the full dataset.")
             return None, None
 
     start_date = _parse_date(start_date, is_end=False) if start_date else None
@@ -132,9 +130,7 @@ def _transfrom_to_snake_case(column_name):
     """
     column_name = re.sub(r"(?<!^)(?=[A-Z])", "_", column_name)
     column_name = column_name.replace(" ", "_").replace("-", "_").lower()
-    column_name = "".join(
-        c if c.isalnum() or c == "_" else "_" for c in column_name
-    )
+    column_name = "".join(c if c.isalnum() or c == "_" else "_" for c in column_name)
 
     while "__" in column_name:
         column_name = column_name.replace("__", "_")

--- a/tidyfinance/backend.py
+++ b/tidyfinance/backend.py
@@ -101,7 +101,9 @@ def _convert_output(obj):
     unchanged. With the '"polars"' backend, a pandas data frame is
     converted via :func:'polars.from_pandas'. A non-default index (a
     named index or a non-'RangeIndex', such as a date index) is
-    preserved as a column, since polars has no concept of an index.
+    preserved as a column, since polars has no concept of an index. A
+    'date' column is cast to 'polars.Date' so it prints as
+    'YYYY-MM-DD' instead of a datetime with a trailing zero time.
     """
     if get_backend() != "polars":
         return obj
@@ -116,7 +118,10 @@ def _convert_output(obj):
     include_index = not (
         isinstance(obj.index, pd.RangeIndex) and obj.index.name is None
     )
-    return pl.from_pandas(obj, include_index=include_index)
+    out = pl.from_pandas(obj, include_index=include_index)
+    if "date" in out.columns and out.schema["date"] == pl.Datetime:
+        out = out.with_columns(pl.col("date").cast(pl.Date))
+    return out
 
 
 def _use_backend(func):

--- a/tidyfinance/download.py
+++ b/tidyfinance/download.py
@@ -4,20 +4,24 @@ import warnings
 
 import pandas as pd
 
-from .download_open_source import (_download_data_constituents,
-                                   _download_data_factors_ff,
-                                   _download_data_factors_q,
-                                   _download_data_fred,
-                                   _download_data_macro_predictors,
-                                   _download_data_osap,
-                                   _download_data_stock_prices)
+from .download_open_source import (
+    _download_data_constituents,
+    _download_data_factors_ff,
+    _download_data_factors_q,
+    _download_data_fred,
+    _download_data_macro_predictors,
+    _download_data_osap,
+    _download_data_stock_prices,
+)
 from .download_pseudo import _simulate_pseudo_data
-from .download_tidy_finance import (_download_data_huggingface,
-                                    _download_data_risk_free)
+from .download_tidy_finance import _download_data_huggingface, _download_data_risk_free
 from .download_wrds import _download_data_wrds
-from .supported_datasets import (_check_supported_domain, _is_legacy_type,
-                                 _parse_type_to_domain_dataset,
-                                 _resolve_domain_alias)
+from .supported_datasets import (
+    _check_supported_domain,
+    _is_legacy_type,
+    _parse_type_to_domain_dataset,
+    _resolve_domain_alias,
+)
 
 
 def download_data(

--- a/tidyfinance/download_open_source.py
+++ b/tidyfinance/download_open_source.py
@@ -10,12 +10,15 @@ import numpy as np
 import pandas as pd
 from curl_cffi import requests
 
-from ._internal import (_get_random_user_agent, _transfrom_to_snake_case,
-                        _validate_dates)
-from .supported_datasets import (_check_supported_dataset_ff,
-                                 _determine_frequency_ff, _is_breakpoints_ff,
-                                 _is_legacy_type_ff, _is_legacy_type_q,
-                                 _parse_type_to_domain_dataset)
+from ._internal import _get_random_user_agent, _transfrom_to_snake_case, _validate_dates
+from .supported_datasets import (
+    _check_supported_dataset_ff,
+    _determine_frequency_ff,
+    _is_breakpoints_ff,
+    _is_legacy_type_ff,
+    _is_legacy_type_q,
+    _parse_type_to_domain_dataset,
+)
 from .utilities import list_supported_indexes
 
 # %% functions
@@ -44,14 +47,11 @@ def get_available_famafrench_datasets():
     response = requests.get(f"{ff_url}data_library.html")
     root = document_fromstring(response.content)
 
-    datasets = [
-        e.attrib["href"] for e in root.findall(".//a") if "href" in e.attrib
-    ]
+    datasets = [e.attrib["href"] for e in root.findall(".//a") if "href" in e.attrib]
     datasets = [
         dataset_i
         for dataset_i in datasets
-        if dataset_i.startswith(ff_url_prefix)
-        and dataset_i.endswith(ff_url_suffix)
+        if dataset_i.startswith(ff_url_prefix) and dataset_i.endswith(ff_url_suffix)
     ]
     datasets_list = list(
         map(lambda x: x[len(ff_url_prefix) : -len(ff_url_suffix)], datasets)
@@ -282,18 +282,14 @@ def _download_data_factors_ff(
                 raw_downloaded.reset_index()
                 .rename(
                     columns=lambda x: (
-                        x.lower()
-                        .replace("-rf", "_excess")
-                        .replace("rf", "risk_free")
+                        x.lower().replace("-rf", "_excess").replace("rf", "risk_free")
                         if isinstance(x, str)
                         else x
                     )
                 )
                 .apply(
                     lambda x: (
-                        x.replace([-99.99, -999], np.nan)
-                        if x.name != "date"
-                        else x
+                        x.replace([-99.99, -999], np.nan) if x.name != "date" else x
                     )
                 )
             )
@@ -409,22 +405,16 @@ def _download_data_factors_q(
         )
     try:
         raw_data = (
-            pd.read_csv(
-                f"{url}{dataset}.csv", engine="python", on_bad_lines="skip"
-            )
+            pd.read_csv(f"{url}{dataset}.csv", engine="python", on_bad_lines="skip")
             .rename(columns=lambda x: x.lower().replace("r_", ""))
             .rename(columns={"f": "risk_free", "mkt": "mkt_excess"})
         )
     except Exception as e:
-        raise ValueError(
-            f"Could not download or parse dataset '{dataset}': {e}"
-        ) from e
+        raise ValueError(f"Could not download or parse dataset '{dataset}': {e}") from e
 
     if "monthly" in dataset:
         raw_data = raw_data.assign(
-            date=pd.to_datetime(
-                dict(year=raw_data.year, month=raw_data.month, day=1)
-            )
+            date=pd.to_datetime(dict(year=raw_data.year, month=raw_data.month, day=1))
         ).drop(columns=["year", "month"])
     if "weekly" in dataset:
         raw_data = raw_data.assign(
@@ -569,9 +559,7 @@ def _download_data_macro_predictors(
             date=lambda x: pd.to_datetime(
                 x["yyyyq"].astype(str).str[:4]
                 + "-"
-                + (x["yyyyq"].astype(str).str[4].astype(int) * 3 - 2).astype(
-                    str
-                )
+                + (x["yyyyq"].astype(str).str[4].astype(int) * 3 - 2).astype(str)
                 + "-01"
             )
         ).drop(columns=["yyyyq"])
@@ -596,9 +584,7 @@ def _download_data_macro_predictors(
     ).assign(
         IndexDiv=lambda df: df["Index"] + df["D12"],
         logret=lambda df: (
-            df["IndexDiv"]
-            .apply(lambda x: np.nan if pd.isna(x) else np.log(x))
-            .diff()
+            df["IndexDiv"].apply(lambda x: np.nan if pd.isna(x) else np.log(x)).diff()
         ),
         rp_div=lambda df: df["logret"].shift(-1) - df["Rfree"],
         log_d12=lambda df: df["D12"].apply(
@@ -613,9 +599,7 @@ def _download_data_macro_predictors(
         ),
         dy=lambda df: (
             df["log_d12"]
-            - df["Index"]
-            .shift(1)
-            .apply(lambda x: np.nan if pd.isna(x) else np.log(x))
+            - df["Index"].shift(1).apply(lambda x: np.nan if pd.isna(x) else np.log(x))
         ),
         ep=lambda df: (
             df["log_e12"]
@@ -729,9 +713,7 @@ def _download_data_constituents(
             f"Supported indexes: {', '.join(supported_indexes['index'])}"
         )
 
-    url = supported_indexes.loc[
-        supported_indexes["index"] == index, "url"
-    ].values[0]
+    url = supported_indexes.loc[supported_indexes["index"] == index, "url"].values[0]
     skip_rows = supported_indexes.loc[
         supported_indexes["index"] == index, "skip"
     ].values[0]
@@ -925,11 +907,7 @@ def _download_data_fred(
                                 x[x.columns[x.columns.str.contains("date")][0]]
                             ),
                             value=lambda x: pd.to_numeric(
-                                x[
-                                    x.columns[~x.columns.str.contains("date")][
-                                        0
-                                    ]
-                                ],
+                                x[x.columns[~x.columns.str.contains("date")][0]],
                                 errors="coerce",
                             ),
                             series=s,
@@ -955,9 +933,9 @@ def _download_data_fred(
 
     fred_data = pd.concat(fred_data, ignore_index=True)
     if start_date and end_date:
-        fred_data = fred_data.query(
-            "@start_date <= date <= @end_date"
-        ).reset_index(drop=True)
+        fred_data = fred_data.query("@start_date <= date <= @end_date").reset_index(
+            drop=True
+        )
     return fred_data
 
 
@@ -1008,9 +986,7 @@ def _download_data_stock_prices(
     ):
         raise ValueError("symbols must be a list of stock symbols (strings).")
 
-    start_date, end_date = _validate_dates(
-        start_date, end_date, use_default_range=True
-    )
+    start_date, end_date = _validate_dates(start_date, end_date, use_default_range=True)
 
     start_timestamp = int(start_date.timestamp())
     end_timestamp = int(end_date.timestamp())
@@ -1026,9 +1002,7 @@ def _download_data_stock_prices(
 
         headers = {"User-Agent": _get_random_user_agent()}
         try:
-            response = requests.get(
-                url, impersonate="chrome120", headers=headers
-            )
+            response = requests.get(url, impersonate="chrome120", headers=headers)
         except Exception:
             response = requests.get(url, impersonate="chrome120")
 
@@ -1045,9 +1019,7 @@ def _download_data_stock_prices(
 
             timestamps = raw_data[0]["timestamp"]
             indicators = raw_data[0]["indicators"]["quote"][0]
-            adjusted_close = raw_data[0]["indicators"]["adjclose"][0][
-                "adjclose"
-            ]
+            adjusted_close = raw_data[0]["indicators"]["adjclose"][0]["adjclose"]
 
             df_symbol = pd.DataFrame().assign(
                 date=pd.to_datetime(
@@ -1172,9 +1144,7 @@ def _download_data_osap(
             .dt.start_time
         )
 
-    raw_data.columns = [
-        _transfrom_to_snake_case(col) for col in raw_data.columns
-    ]
+    raw_data.columns = [_transfrom_to_snake_case(col) for col in raw_data.columns]
 
     # All columns except the date are long-short returns in percent, so
     # scale them to plain numeric (decimal) returns.

--- a/tidyfinance/download_pseudo.py
+++ b/tidyfinance/download_pseudo.py
@@ -97,10 +97,7 @@ def _simulate_pseudo_identifiers(
     exchange = rng.choice(exchanges, size=n_assets, p=exchange_probs)
     industry = rng.choice(industries, size=n_assets, p=industry_probs)
     siccd = np.array(
-        [
-            rng.integers(_SIC_RANGES[ind][0], _SIC_RANGES[ind][1] + 1)
-            for ind in industry
-        ]
+        [rng.integers(_SIC_RANGES[ind][0], _SIC_RANGES[ind][1] + 1) for ind in industry]
     )
 
     return pd.DataFrame(
@@ -312,9 +309,7 @@ def _download_data_pseudo_crsp(
             "datasets: 'crsp_monthly', 'crsp_daily'."
         )
 
-    start_date, end_date = _validate_dates(
-        start_date, end_date, use_default_range=True
-    )
+    start_date, end_date = _validate_dates(start_date, end_date, use_default_range=True)
 
     identifiers = _simulate_pseudo_identifiers(n_assets=n_assets, seed=seed)
 
@@ -328,9 +323,7 @@ def _download_data_pseudo_crsp(
         )
 
     if add_ccm_links:
-        panel = panel.merge(
-            identifiers[["permno", "gvkey"]], on="permno", how="left"
-        )
+        panel = panel.merge(identifiers[["permno", "gvkey"]], on="permno", how="left")
 
     return panel
 
@@ -585,9 +578,7 @@ def _download_data_pseudo_compustat(
             "'compustat_quarterly'."
         )
 
-    start_date, end_date = _validate_dates(
-        start_date, end_date, use_default_range=True
-    )
+    start_date, end_date = _validate_dates(start_date, end_date, use_default_range=True)
 
     identifiers = _simulate_pseudo_identifiers(n_assets=n_assets, seed=seed)
 
@@ -639,9 +630,7 @@ def _simulate_pseudo_compustat_annual(
         Compustat-style accounting columns, followed by any requested
         'additional_columns'.
     """
-    years = np.arange(
-        pd.Timestamp(start_date).year, pd.Timestamp(end_date).year + 1
-    )
+    years = np.arange(pd.Timestamp(start_date).year, pd.Timestamp(end_date).year + 1)
     rng = np.random.default_rng(seed + 4)
 
     panel = (
@@ -702,9 +691,7 @@ def _simulate_pseudo_compustat_annual(
             panel["seq"]
             .combine_first(panel["ceq"] + panel["pstk"])
             .combine_first(panel["at"] - panel["lt"])
-            + panel["txditc"]
-            .combine_first(panel["txdb"] + panel["itcb"])
-            .fillna(0)
+            + panel["txditc"].combine_first(panel["txdb"] + panel["itcb"]).fillna(0)
             - panel["pstkrv"]
             .combine_first(panel["pstkl"])
             .combine_first(panel["pstk"])
@@ -728,9 +715,7 @@ def _simulate_pseudo_compustat_annual(
     )
     panel = panel.merge(lag, on=["gvkey", "year"], how="left")
     panel = panel.assign(
-        inv=np.where(
-            panel["at_lag"] <= 0, np.nan, panel["at"] / panel["at_lag"] - 1
-        )
+        inv=np.where(panel["at_lag"] <= 0, np.nan, panel["at"] / panel["at_lag"] - 1)
     )
 
     first_cols = ["gvkey", "date", "datadate"]

--- a/tidyfinance/download_tidy_finance.py
+++ b/tidyfinance/download_tidy_finance.py
@@ -149,9 +149,7 @@ def _download_data_risk_free(
 # %% hugging face functions for tidy finance data
 
 
-def _get_available_huggingface_files(
-    organization: str, dataset: str
-) -> pd.DataFrame:
+def _get_available_huggingface_files(organization: str, dataset: str) -> pd.DataFrame:
     """
     List parquet files in a Hugging Face dataset.
 
@@ -235,9 +233,7 @@ def _download_factor_library_grid() -> pd.DataFrame:
     _download_factor_library_grid()
     ```
     """
-    available = _get_available_huggingface_files(
-        "tidy-finance", "factor-library-grid"
-    )
+    available = _get_available_huggingface_files("tidy-finance", "factor-library-grid")
     if available.empty or "path" not in available.columns:
         raise ValueError(
             "No parquet files were found in the Hugging Face dataset repo "
@@ -423,22 +419,16 @@ def _download_factor_library_ids(ids: list) -> pd.DataFrame:
     organization = "tidy-finance"
     dataset_name = "factor-library"
 
-    path_pattern = re.compile(
-        r"sorting_variable=([^/]+)/sorting_variable_lag=([^/]+)/"
-    )
-    available_files = _get_available_huggingface_files(
-        organization, dataset_name
-    )
+    path_pattern = re.compile(r"sorting_variable=([^/]+)/sorting_variable_lag=([^/]+)/")
+    available_files = _get_available_huggingface_files(organization, dataset_name)
 
     def _extract_keys(path: str) -> tuple:
         m = path_pattern.search(path)
         return (m.group(1), m.group(2)) if m else (None, None)
 
-    available_files[["sorting_variable", "sorting_variable_lag"]] = (
-        pd.DataFrame(
-            available_files["path"].apply(_extract_keys).tolist(),
-            index=available_files.index,
-        )
+    available_files[["sorting_variable", "sorting_variable_lag"]] = pd.DataFrame(
+        available_files["path"].apply(_extract_keys).tolist(),
+        index=available_files.index,
     )
 
     grid = _download_factor_library_grid().assign(
@@ -474,9 +464,7 @@ def _download_factor_library_ids(ids: list) -> pd.DataFrame:
         )
 
     with ThreadPoolExecutor(max_workers=8) as ex:
-        frames = list(
-            ex.map(_fetch_parquet_url, [_make_url(p) for p in unique_paths])
-        )
+        frames = list(ex.map(_fetch_parquet_url, [_make_url(p) for p in unique_paths]))
 
     returns = pd.concat(frames, ignore_index=True)
 
@@ -747,18 +735,14 @@ def _download_data_huggingface(
             end_date = "2007-07-27"
 
         date_pattern = re.compile(r"date=(\d{4}-\d{2}-\d{2})")
-        available_files = _get_available_huggingface_files(
-            organization, dataset_name
-        )
+        available_files = _get_available_huggingface_files(organization, dataset_name)
         available_files["date"] = pd.to_datetime(
             available_files["path"].str.extract(date_pattern, expand=False),
             format="%Y-%m-%d",
         ).dt.date
 
         requested_dates = set(
-            pd.date_range(
-                start=str(start_date), end=str(end_date), freq="D"
-            ).date
+            pd.date_range(start=str(start_date), end=str(end_date), freq="D").date
         )
         files_to_download = available_files.loc[
             available_files["date"].isin(requested_dates)

--- a/tidyfinance/lagging.py
+++ b/tidyfinance/lagging.py
@@ -128,9 +128,7 @@ def add_lagged_columns(
     if by_list:
         missing_by = [c for c in by_list if c not in data.columns]
         if missing_by:
-            raise ValueError(
-                f"'data' is missing grouping column(s): {missing_by}."
-            )
+            raise ValueError(f"'data' is missing grouping column(s): {missing_by}.")
 
     join_cols = by_list + [date_col]
     if data[join_cols].duplicated().any():
@@ -149,9 +147,7 @@ def add_lagged_columns(
     for col in cols:
         lag_col_name = f"{col}_lag"
         if lag_col_name in result.columns:
-            raise ValueError(
-                f"Column '{lag_col_name}' already exists in 'data'."
-            )
+            raise ValueError(f"Column '{lag_col_name}' already exists in 'data'.")
 
         lagged = data[join_cols + [col]].copy()
 
@@ -240,9 +236,9 @@ def _window_lag_join(
     left_sorted["_upper"] = pd.to_datetime(left_sorted["_upper"]).astype(
         "datetime64[ns]"
     )
-    right_sorted["_src_date"] = pd.to_datetime(
-        right_sorted["_src_date"]
-    ).astype("datetime64[ns]")
+    right_sorted["_src_date"] = pd.to_datetime(right_sorted["_src_date"]).astype(
+        "datetime64[ns]"
+    )
 
     merged = pd.merge_asof(
         left_sorted,
@@ -253,15 +249,11 @@ def _window_lag_join(
         direction="backward",
     )
 
-    mask = merged["_src_date"].notna() & (
-        merged["_src_date"] >= merged["_lower"]
-    )
+    mask = merged["_src_date"].notna() & (merged["_src_date"] >= merged["_lower"])
     merged.loc[~mask, lag_col_name] = np.nan
 
     merged = merged.sort_values("_orig_idx", kind="mergesort")
-    merged = merged.drop(columns=["_orig_idx", "_src_date"]).reset_index(
-        drop=True
-    )
+    merged = merged.drop(columns=["_orig_idx", "_src_date"]).reset_index(drop=True)
     return merged
 
 
@@ -343,18 +335,14 @@ def join_lagged_values(
 
     if isinstance(id_keys, str):
         id_keys = [id_keys]
-    if not isinstance(id_keys, list) or not all(
-        isinstance(k, str) for k in id_keys
-    ):
+    if not isinstance(id_keys, list) or not all(isinstance(k, str) for k in id_keys):
         raise ValueError("'id_keys' must be a string or list of strings.")
 
     min_lag_offset = _to_offset(min_lag)
     max_lag_offset = _to_offset(max_lag)
 
     if date_col not in original_data.columns:
-        raise ValueError(
-            f"'original_data' must contain the column '{date_col}'."
-        )
+        raise ValueError(f"'original_data' must contain the column '{date_col}'.")
     if date_col not in new_data.columns:
         raise ValueError(f"'new_data' must contain the column '{date_col}'.")
 
@@ -368,13 +356,10 @@ def join_lagged_values(
     if missing_new:
         raise ValueError(f"'new_data' is missing id column(s): {missing_new}.")
 
-    new_column_names = [
-        c for c in new_data.columns if c not in id_keys + [date_col]
-    ]
+    new_column_names = [c for c in new_data.columns if c not in id_keys + [date_col]]
     if not new_column_names:
         raise ValueError(
-            f"'new_data' must contain columns besides {id_keys} and "
-            f"'{date_col}'."
+            f"'new_data' must contain columns besides {id_keys} and " f"'{date_col}'."
         )
 
     original_non_key = [
@@ -409,9 +394,7 @@ def join_lagged_values(
         if ff_adjustment:
             grp_cols = id_keys + ["_year"]
             max_dates = tmp.groupby(grp_cols)[date_col].transform("max")
-            tmp = tmp[tmp[date_col] == max_dates].drop(
-                columns=[date_col, "_year"]
-            )
+            tmp = tmp[tmp[date_col] == max_dates].drop(columns=[date_col, "_year"])
         else:
             tmp = tmp.drop(columns=[date_col])
 
@@ -444,9 +427,9 @@ def join_lagged_values(
         merged.loc[~mask, col] = np.nan
 
         merged = merged.sort_values("_orig_idx", kind="mergesort")
-        merged = merged.drop(
-            columns=["_orig_idx", "_lower", "_upper"]
-        ).reset_index(drop=True)
+        merged = merged.drop(columns=["_orig_idx", "_lower", "_upper"]).reset_index(
+            drop=True
+        )
         result = merged
 
     return result
@@ -522,9 +505,7 @@ def compute_rolling_value(
     date_col = data_options.get("date")
 
     if not isinstance(date_col, str):
-        raise ValueError(
-            "'date' in data_options must be a single non-missing string."
-        )
+        raise ValueError("'date' in data_options must be a single non-missing string.")
 
     if date_col not in data.columns:
         raise ValueError(f"'data' must contain a '{date_col}' column.")

--- a/tidyfinance/regression.py
+++ b/tidyfinance/regression.py
@@ -611,9 +611,7 @@ def estimate_fama_macbeth(
 
     # Compute time-series averages
     price_of_risk = (
-        risk_premiums.melt(
-            id_vars=date_col, var_name="factor", value_name="estimate"
-        )
+        risk_premiums.melt(id_vars=date_col, var_name="factor", value_name="estimate")
         .groupby("factor")["estimate"]
         .mean()
         .reset_index()
@@ -642,9 +640,9 @@ def estimate_fama_macbeth(
                 adjust=nw_adjust,
             )
         else:
-            se = _fit_ols(
-                "estimate ~ 1", data=x.dropna(subset=["estimate"])
-            ).se()["Intercept"]
+            se = _fit_ols("estimate ~ 1", data=x.dropna(subset=["estimate"])).se()[
+                "Intercept"
+            ]
         if se is None or np.isnan(se) or se == 0:
             t_stat = np.nan
         else:
@@ -658,9 +656,7 @@ def estimate_fama_macbeth(
         )
 
     price_of_risk_se_t_n = (
-        risk_premiums.melt(
-            id_vars=date_col, var_name="factor", value_name="estimate"
-        )
+        risk_premiums.melt(id_vars=date_col, var_name="factor", value_name="estimate")
         .groupby("factor")
         .apply(compute_se_and_t, include_groups=False)
         .reset_index()
@@ -793,9 +789,7 @@ def estimate_model(
     complete = data[model_vars].notna().all(axis=1)
     n_complete = int(complete.sum())
 
-    insufficient = (n_complete < min_obs) or (
-        n_complete <= len(independent_vars)
-    )
+    insufficient = (n_complete < min_obs) or (n_complete <= len(independent_vars))
 
     fit = None
     if not insufficient:

--- a/tidyfinance/utilities.py
+++ b/tidyfinance/utilities.py
@@ -89,9 +89,7 @@ def create_summary_statistics(
     """
     # Check that all specified variables are numeric or boolean
     non_numeric_vars = [
-        var
-        for var in variables
-        if not pd.api.types.is_numeric_dtype(data[var].dtype)
+        var for var in variables if not pd.api.types.is_numeric_dtype(data[var].dtype)
     ]
     if non_numeric_vars:
         raise ValueError(
@@ -102,9 +100,7 @@ def create_summary_statistics(
     # Cast boolean columns to float so they survive `describe()`, which
     # drops bool dtype by default. The mean of the cast column then
     # equals the proportion of True in the original.
-    bool_cols = [
-        v for v in variables if pd.api.types.is_bool_dtype(data[v].dtype)
-    ]
+    bool_cols = [v for v in variables if pd.api.types.is_bool_dtype(data[v].dtype)]
     if bool_cols:
         data = data.copy()
         for c in bool_cols:
@@ -116,9 +112,7 @@ def create_summary_statistics(
 
     # Compute summary statistics using describe
     percentiles = (
-        [0.5]
-        if not detail
-        else [0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99]
+        [0.5] if not detail else [0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99]
     )
 
     if by:

--- a/uv.lock
+++ b/uv.lock
@@ -2750,7 +2750,7 @@ wheels = [
 
 [[package]]
 name = "tidyfinance"
-version = "0.3.1.dev1"
+version = "0.3.1.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary
- `_convert_output` in `tidyfinance/backend.py` now casts a `date` column from `Datetime` to `polars.Date` when converting to the polars backend, so it renders as `YYYY-MM-DD` instead of a datetime with a trailing time component.
- Applied `uv run ruff format` across `_internal.py`, `download.py`, `download_open_source.py`, `download_pseudo.py`, `download_tidy_finance.py`, `lagging.py`, `regression.py`, and `utilities.py` (whitespace/import-wrapping only, no logic changes).
- Added a test covering the new `date` -> `polars.Date` cast in `tests/test_backend.py`.

## Test plan
- [x] `uv run pytest -q` (592 passed)
- [x] `uv run ruff format --check` on touched files