### PR TITLE
Add Global Factor Data, Pastor-Stambaugh, and Stambaugh-Yuan downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Added Global Factor Data, Pastor-Stambaugh, and Stambaugh-Yuan
+  downloads:** `download_data("Global Factor Data")` downloads
+  characteristic-managed portfolio returns, the underlying long-short
+  portfolios, industry returns, or reference cutoff files from
+  [Global Factor Data](https://jkpfactors.com/data) (Jensen, Kelly, and
+  Pedersen, 2023); the requested selection is validated against the
+  library's live availability manifest, and
+  `list_supported_jkp_factors()` lists the available regions and
+  factors. `download_data("Pastor-Stambaugh")` downloads the liquidity
+  factors of Pastor and Stambaugh (2003). `download_data("Stambaugh-Yuan")`
+  downloads the mispricing factors of Stambaugh and Yuan (2017), with a
+  `dataset` argument selecting `"monthly"` (default) or `"daily"` data.
 - **OSAP download aligned with beginning-of-month and scaled returns:**
   `download_data("Open Source Asset Pricing")` now aligns the `date`
   column to the beginning of the month (the dataset previously returned

--- a/README.md
+++ b/README.md
@@ -106,6 +106,56 @@ tf.download_data(
 )
 ```
 
+To download characteristic-managed portfolio (factor) returns from [Global Factor Data](https://jkpfactors.com/data), select a region, the factor content (a single factor, a theme, `"all_themes"`, or `"all_factors"`), a frequency, and a weighting scheme:
+
+```python
+tf.download_data(
+  domain="Global Factor Data",
+  region="usa",
+  factors="all_factors",
+  frequency="monthly",
+  weighting="vw_cap",
+  start_date="2020-01-01",
+  end_date="2020-12-31"
+)
+```
+
+The `dataset` argument also gives access to the underlying long-short portfolios (`"portfolios"`), industry returns (`"industry"`), and the reference files `"nyse_cutoffs"` and `"return_cutoffs"`:
+
+```python
+tf.download_data(
+  domain="Global Factor Data",
+  dataset="industry",
+  region="usa",
+  classification="gics",
+  start_date="2020-01-01",
+  end_date="2020-12-31"
+)
+```
+
+Use `tf.list_supported_jkp_factors()` to see the available regions, or `tf.list_supported_jkp_factors("usa")` to see the factors available for a region.
+
+To download the liquidity factors of Pastor and Stambaugh (2003) from [Lubos Pastor's data library](https://faculty.chicagobooth.edu/lubos-pastor/data):
+
+```python
+tf.download_data(
+  domain="Pastor-Stambaugh",
+  start_date="2020-01-01",
+  end_date="2020-12-31"
+)
+```
+
+To download the mispricing factors of Stambaugh and Yuan (2017) from [Robert Stambaugh's data library](https://finance.wharton.upenn.edu/~stambaug/), optionally selecting `"monthly"` (the default) or `"daily"` data. Note that the source files currently end in December 2016:
+
+```python
+tf.download_data(
+  domain="Stambaugh-Yuan",
+  dataset="monthly",
+  start_date="2015-01-01",
+  end_date="2016-12-31"
+)
+```
+
 To download multiple series from the Federal Reserve Economic Data (FRED):
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Christoph Frey", email = "christoph.frey@gmail.com"},
 	   {name = "Christoph Scheuch", email = "christoph@tidy-intelligence.com"},
        {name = "Stefan Voigt", email = "stefan.voigt@econ.ku.dk"}
            ]
-version = "0.3.1.dev2"
+version = "0.3.1.dev3"
 description = "Tidy Finance Helper Functions"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_download_data.py
+++ b/tests/test_download_data.py
@@ -95,6 +95,47 @@ def test_download_data_pseudo_dispatches_to_simulate():
     assert {"permno", "date", "ret"}.issubset(result.columns)
 
 
+def test_download_data_forwards_dataset_to_global_factor_data():
+    """A missing 'dataset' defaults to 'factors'; explicit values pass through."""
+    with patch("tidyfinance.download._download_data_jkp") as mock_jkp:
+        mock_jkp.return_value = "sentinel"
+
+        download_data(domain="Global Factor Data")
+        assert mock_jkp.call_args.kwargs["dataset"] == "factors"
+
+        download_data(domain="Global Factor Data", dataset="industry")
+        assert mock_jkp.call_args.kwargs["dataset"] == "industry"
+
+
+def test_download_data_forwards_dataset_to_stambaugh_yuan():
+    """A missing 'dataset' defaults to 'monthly'; explicit values pass through."""
+    with patch("tidyfinance.download._download_data_stambaugh_yuan") as mock_sy:
+        mock_sy.return_value = "sentinel"
+
+        download_data(domain="Stambaugh-Yuan")
+        assert mock_sy.call_args.kwargs["dataset"] == "monthly"
+
+        download_data(domain="Stambaugh-Yuan", dataset="daily")
+        assert mock_sy.call_args.kwargs["dataset"] == "daily"
+
+
+def test_download_data_dispatches_pastor_stambaugh():
+    """domain='Pastor-Stambaugh' routes to _download_data_pastor_stambaugh."""
+    with patch(
+        "tidyfinance.download._download_data_pastor_stambaugh",
+        return_value="sentinel",
+    ) as mock_ps:
+        result = download_data(
+            domain="Pastor-Stambaugh",
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+        )
+    assert result == "sentinel"
+    mock_ps.assert_called_once_with(
+        start_date="2020-01-01", end_date="2020-12-31"
+    )
+
+
 def test_download_data_legacy_domain_alias_warns():
     """Emit DeprecationWarning when a legacy machine-readable domain is used."""
     with patch(

--- a/tests/test_download_data_jkp.py
+++ b/tests/test_download_data_jkp.py
@@ -1,0 +1,404 @@
+"""Tests for download_data_jkp and list_supported_jkp_factors."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.download_open_source import (  # noqa: E402
+    _build_jkp_reference_url,
+    _build_jkp_url,
+    _download_data_jkp,
+)
+from tidyfinance.utilities import list_supported_jkp_factors  # noqa: E402
+
+
+def _manifest():
+    return {
+        "factors": {
+            "usa": ["mkt", "all_factors", "all_themes", "value", "be_me"],
+            "frontier": ["mkt", "all_factors", "aliq_mat"],
+        },
+        "portfolios": {"usa": ["be_me", "ret_12_1"]},
+        "industry": {"usa": ["gics", "ff49"]},
+        "factors_monthly_only": {"frontier": ["aliq_mat"]},
+    }
+
+
+# %% _download_data_jkp: factors
+
+
+def test_downloads_and_processes_monthly_factor_returns():
+    raw = pd.DataFrame(
+        {
+            "location": "usa",
+            "name": "mkt",
+            "freq": "monthly",
+            "weighting": "vw_cap",
+            "n_stocks": [494, 505],
+            "date": ["1926-01-31", "1926-02-28"],
+            "ret": [0.001, -0.046],
+        }
+    )
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            return_value=raw,
+        ),
+    ):
+        result = _download_data_jkp(region="usa", factors="mkt")
+
+    assert isinstance(result, pd.DataFrame)
+    # Dates are aligned to the beginning of the month.
+    assert list(result["date"]) == [
+        pd.Timestamp("1926-01-01"),
+        pd.Timestamp("1926-02-01"),
+    ]
+    # Returns are already decimal and must not be rescaled.
+    assert list(result["ret"]) == [0.001, -0.046]
+
+
+def test_keeps_daily_dates_as_is():
+    raw = pd.DataFrame(
+        {"date": ["2020-01-02", "2020-01-03"], "ret": [0.01, 0.02]}
+    )
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            return_value=raw,
+        ),
+    ):
+        result = _download_data_jkp(
+            region="usa", factors="mkt", frequency="daily"
+        )
+
+    assert list(result["date"]) == [
+        pd.Timestamp("2020-01-02"),
+        pd.Timestamp("2020-01-03"),
+    ]
+
+
+def test_downloads_portfolios_and_coerces_pf_to_integer():
+    raw = pd.DataFrame(
+        {
+            "location": "usa",
+            "name": "be_me",
+            "pf": [1.0, 3.0],
+            "n": [494, 497],
+            "freq": "monthly",
+            "weighting": "vw_cap",
+            "date": ["1926-01-31", "1926-01-31"],
+            "ret": [0.001, -0.002],
+        }
+    )
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            return_value=raw,
+        ),
+    ):
+        result = _download_data_jkp(dataset="portfolios", factors="be_me")
+
+    assert result["pf"].dtype.kind == "i"
+    assert list(result["pf"]) == [1, 3]
+    assert list(result["date"]) == [
+        pd.Timestamp("1926-01-01"),
+        pd.Timestamp("1926-01-01"),
+    ]
+
+
+def test_downloads_industry_returns_at_monthly_frequency():
+    raw = pd.DataFrame(
+        {
+            "gics": [55, 15],
+            "date": ["1999-07-31", "1999-07-31"],
+            "n": [170, 376],
+            "location": "usa",
+            "ret": [-0.004, -0.036],
+            "freq": "monthly",
+            "weighting": "vw_cap",
+        }
+    )
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            return_value=raw,
+        ),
+    ):
+        result = _download_data_jkp(dataset="industry", classification="gics")
+
+    assert list(result["date"]) == [
+        pd.Timestamp("1999-07-01"),
+        pd.Timestamp("1999-07-01"),
+    ]
+    assert "gics" in result.columns
+
+
+# %% _download_data_jkp: reference datasets
+
+
+def test_downloads_reference_cutoffs_and_renames_eom_to_date():
+    raw = pd.DataFrame(
+        {
+            "eom": ["1925-12-31", "1926-01-31"],
+            "n": [495, 508],
+            "nyse_p50": [15.84, 16.25],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source._download_jkp_csv", return_value=raw
+    ):
+        result = _download_data_jkp(dataset="nyse_cutoffs")
+
+    assert "date" in result.columns
+    assert "eom" not in result.columns
+    assert list(result["date"]) == [
+        pd.Timestamp("1925-12-01"),
+        pd.Timestamp("1926-01-01"),
+    ]
+
+
+def test_return_cutoffs_selects_the_daily_file_by_frequency():
+    captured_url = {}
+
+    def fake_download(url, *args, **kwargs):
+        captured_url["url"] = url
+        return pd.DataFrame({"eom": ["2020-01-31"], "ret_1": [-0.14]})
+
+    with patch(
+        "tidyfinance.download_open_source._download_jkp_csv",
+        side_effect=fake_download,
+    ):
+        _download_data_jkp(dataset="return_cutoffs", frequency="daily")
+
+    assert captured_url["url"].endswith("return_cutoffs_daily.csv")
+
+
+def test_returns_empty_dataframe_when_a_reference_download_fails():
+    with patch(
+        "tidyfinance.download_open_source._download_jkp_csv",
+        side_effect=Exception("boom"),
+    ):
+        with pytest.warns(UserWarning, match="download or parsing failure"):
+            result = _download_data_jkp(dataset="nyse_cutoffs")
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+# %% _download_data_jkp: date filtering
+
+
+def test_filters_rows_when_both_dates_are_supplied():
+    raw = pd.DataFrame(
+        {
+            "date": ["2020-01-31", "2020-02-29", "2020-03-31"],
+            "ret": [1, 2, 3],
+        }
+    )
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            return_value=raw,
+        ),
+    ):
+        result = _download_data_jkp(
+            region="usa",
+            factors="mkt",
+            start_date="2020-02-01",
+            end_date="2020-02-28",
+        )
+
+    assert len(result) == 1
+    assert result["date"].iloc[0] == pd.Timestamp("2020-02-01")
+
+
+# %% _download_data_jkp: validation errors
+
+
+def test_aborts_on_unsupported_dataset():
+    with pytest.raises(ValueError, match="dataset"):
+        _download_data_jkp(dataset="bogus")
+
+
+def test_aborts_on_daily_request_for_the_industry_dataset():
+    with pytest.raises(ValueError, match="monthly frequency"):
+        _download_data_jkp(dataset="industry", frequency="daily")
+
+
+def test_aborts_on_invalid_region():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        return_value=_manifest(),
+    ):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _download_data_jkp(region="atlantis", factors="mkt")
+
+
+def test_aborts_on_factor_not_available_in_region():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        return_value=_manifest(),
+    ):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _download_data_jkp(region="frontier", factors="value")
+
+
+def test_aborts_on_invalid_industry_classification():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        return_value=_manifest(),
+    ):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _download_data_jkp(
+                dataset="industry", region="usa", classification="naics"
+            )
+
+
+def test_aborts_on_daily_request_for_a_monthly_only_factor():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        return_value=_manifest(),
+    ):
+        with pytest.raises(ValueError, match="only available at monthly"):
+            _download_data_jkp(
+                region="frontier", factors="aliq_mat", frequency="daily"
+            )
+
+
+def test_aborts_on_invalid_frequency_or_weighting():
+    with pytest.raises(ValueError, match="frequency"):
+        _download_data_jkp(frequency="weekly")
+    with pytest.raises(ValueError, match="weighting"):
+        _download_data_jkp(weighting="gdp_weighted")
+
+
+def test_returns_empty_dataframe_when_the_manifest_is_unavailable():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        side_effect=Exception("boom"),
+    ):
+        with pytest.warns(UserWarning, match="download failure"):
+            result = _download_data_jkp()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+def test_returns_empty_dataframe_when_a_factor_download_fails():
+    with (
+        patch(
+            "tidyfinance.download_open_source._fetch_jkp_availability",
+            return_value=_manifest(),
+        ),
+        patch(
+            "tidyfinance.download_open_source._download_jkp_file",
+            side_effect=Exception("boom"),
+        ),
+    ):
+        with pytest.warns(UserWarning, match="download or parsing failure"):
+            result = _download_data_jkp(region="usa", factors="mkt")
+
+    assert len(result) == 0
+
+
+# %% _build_jkp_url / _build_jkp_reference_url
+
+
+def test_builds_the_bracketed_s3_object_keys():
+    assert _build_jkp_url(
+        "factors", "usa", "all_factors", "monthly", "vw_cap"
+    ) == (
+        "https://jkpfactors-data.s3.amazonaws.com/public/"
+        "%5Busa%5D_%5Ball_factors%5D_%5Bmonthly%5D_%5Bvw_cap%5D.zip"
+    )
+    assert _build_jkp_url(
+        "portfolios", "usa", "be_me", "monthly", "vw_cap"
+    ) == (
+        "https://jkpfactors-data.s3.amazonaws.com/public/portfolios/"
+        "%5Busa%5D_%5Bbe_me%5D_%5Bmonthly%5D_%5Bvw_cap%5D.zip"
+    )
+    # Industry always uses the monthly key regardless of frequency.
+    assert _build_jkp_url("industry", "usa", "gics", "daily", "ew") == (
+        "https://jkpfactors-data.s3.amazonaws.com/public/industry/"
+        "%5Busa%5D_%5Bgics%5D_%5Bmonthly%5D_%5Bew%5D.zip"
+    )
+
+
+def test_builds_reference_file_urls():
+    assert _build_jkp_reference_url("nyse_cutoffs", "monthly").endswith(
+        "/public/other/nyse_cutoffs.csv"
+    )
+    assert _build_jkp_reference_url("return_cutoffs", "monthly").endswith(
+        "/public/other/return_cutoffs.csv"
+    )
+    assert _build_jkp_reference_url("return_cutoffs", "daily").endswith(
+        "/public/other/return_cutoffs_daily.csv"
+    )
+
+
+# %% list_supported_jkp_factors
+
+
+def test_list_supported_jkp_factors_returns_regions_and_per_region_values():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        return_value=_manifest(),
+    ):
+        regions = list_supported_jkp_factors()
+        assert isinstance(regions, pd.DataFrame)
+        assert list(regions["region"]) == ["usa", "frontier"]
+        assert "be_me" in list_supported_jkp_factors("usa")["factor"].values
+        assert list(
+            list_supported_jkp_factors("usa", dataset="industry")["factor"]
+        ) == ["gics", "ff49"]
+        with pytest.raises(ValueError, match="Unsupported"):
+            list_supported_jkp_factors("atlantis")
+
+
+def test_list_supported_jkp_factors_aborts_on_unsupported_dataset():
+    with pytest.raises(ValueError, match="dataset"):
+        list_supported_jkp_factors(dataset="bogus")
+
+
+def test_list_supported_jkp_factors_returns_empty_dataframe_on_failure():
+    with patch(
+        "tidyfinance.download_open_source._fetch_jkp_availability",
+        side_effect=Exception("boom"),
+    ):
+        with pytest.warns(UserWarning, match="download failure"):
+            result = list_supported_jkp_factors()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+if __name__ == "__main__":
+    # Run all tests
+    pytest.main([__file__])

--- a/tests/test_download_data_pastor_stambaugh.py
+++ b/tests/test_download_data_pastor_stambaugh.py
@@ -1,0 +1,87 @@
+"""Tests for download_data_pastor_stambaugh."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.download_open_source import (  # noqa: E402
+    _download_data_pastor_stambaugh,
+)
+
+
+def test_downloads_and_processes_liquidity_factors():
+    raw = pd.DataFrame(
+        {
+            "month": [196708, 196801],
+            "agg_liq": [-0.01, 0.02],
+            "innov_liq": [0.03, -0.04],
+            "traded_liq": [-99, 0.05],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv", return_value=raw
+    ):
+        result = _download_data_pastor_stambaugh()
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == [
+        "date",
+        "agg_liq",
+        "innov_liq",
+        "traded_liq",
+    ]
+    # Dates are aligned to the beginning of the month.
+    assert list(result["date"]) == [
+        pd.Timestamp("1967-08-01"),
+        pd.Timestamp("1968-01-01"),
+    ]
+    # Returns are already decimal and must not be rescaled.
+    assert list(result["agg_liq"]) == [-0.01, 0.02]
+    # The -99 sentinel for the pre-1968 traded factor becomes NaN.
+    assert result["traded_liq"].isna().tolist() == [True, False]
+    assert result["traded_liq"].iloc[1] == 0.05
+
+
+def test_filters_rows_when_both_dates_are_supplied():
+    raw = pd.DataFrame(
+        {
+            "month": [202001, 202002, 202003],
+            "agg_liq": [1, 2, 3],
+            "innov_liq": [1, 2, 3],
+            "traded_liq": [1, 2, 3],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv", return_value=raw
+    ):
+        result = _download_data_pastor_stambaugh(
+            start_date="2020-02-01", end_date="2020-02-28"
+        )
+
+    assert len(result) == 1
+    assert result["date"].iloc[0] == pd.Timestamp("2020-02-01")
+    assert result["innov_liq"].iloc[0] == 2
+
+
+def test_returns_empty_dataframe_after_download_failure():
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv",
+        side_effect=Exception("download failure"),
+    ):
+        with pytest.warns(UserWarning, match="Returning an empty dataset"):
+            result = _download_data_pastor_stambaugh()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+if __name__ == "__main__":
+    # Run all tests
+    pytest.main([__file__])

--- a/tests/test_download_data_stambaugh_yuan.py
+++ b/tests/test_download_data_stambaugh_yuan.py
@@ -1,0 +1,147 @@
+"""Tests for download_data_stambaugh_yuan."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance.download_open_source import (  # noqa: E402
+    _download_data_stambaugh_yuan,
+)
+
+
+def test_downloads_and_processes_monthly_mispricing_factors():
+    raw = pd.DataFrame(
+        {
+            "YYYYMM": [196301, 196302],
+            "MKTRF": [0.0493, -0.0238],
+            "SMB": [0.0248, 0.0181],
+            "MGMT": [0.0213, 0.0110],
+            "PERF": [-0.0228, 0.0009],
+            "RF": [0.0025, 0.0023],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv", return_value=raw
+    ):
+        result = _download_data_stambaugh_yuan()
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == [
+        "date",
+        "mkt_excess",
+        "smb",
+        "mgmt",
+        "perf",
+        "risk_free",
+    ]
+    # Dates are aligned to the beginning of the month.
+    assert list(result["date"]) == [
+        pd.Timestamp("1963-01-01"),
+        pd.Timestamp("1963-02-01"),
+    ]
+    # Returns are already decimal and must not be rescaled.
+    assert list(result["mkt_excess"]) == [0.0493, -0.0238]
+    assert list(result["risk_free"]) == [0.0025, 0.0023]
+
+
+def test_parses_daily_dates_from_the_date_column():
+    captured_url = {}
+
+    def fake_read_csv(url, *args, **kwargs):
+        captured_url["url"] = url
+        return pd.DataFrame(
+            {
+                "DATE": [19630102, 19630103],
+                "MKTRF": [-0.0054, 0.0166],
+                "SMB": [0.0094, 0.0053],
+                "MGMT": [0.0062, 0.0050],
+                "PERF": [-0.0073, -0.0215],
+                "RF": [0.00011, 0.00011],
+            }
+        )
+
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv",
+        side_effect=fake_read_csv,
+    ):
+        result = _download_data_stambaugh_yuan(dataset="daily")
+
+    assert captured_url["url"].endswith("M4d.csv")
+    assert list(result["date"]) == [
+        pd.Timestamp("1963-01-02"),
+        pd.Timestamp("1963-01-03"),
+    ]
+
+
+def test_filters_rows_when_both_dates_are_supplied():
+    raw = pd.DataFrame(
+        {
+            "YYYYMM": [196301, 196302, 196303],
+            "MKTRF": [1, 2, 3],
+            "SMB": [1, 2, 3],
+            "MGMT": [1, 2, 3],
+            "PERF": [1, 2, 3],
+            "RF": [1, 2, 3],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv", return_value=raw
+    ):
+        result = _download_data_stambaugh_yuan(
+            start_date="1963-02-01", end_date="1963-02-28"
+        )
+
+    assert len(result) == 1
+    assert result["date"].iloc[0] == pd.Timestamp("1963-02-01")
+
+
+def test_warns_when_the_requested_range_is_outside_the_available_data():
+    raw = pd.DataFrame(
+        {
+            "YYYYMM": [196301, 196302],
+            "MKTRF": [1, 2],
+            "SMB": [1, 2],
+            "MGMT": [1, 2],
+            "PERF": [1, 2],
+            "RF": [1, 2],
+        }
+    )
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv", return_value=raw
+    ):
+        with pytest.warns(UserWarning, match="outside the available"):
+            result = _download_data_stambaugh_yuan(
+                start_date="2020-01-01", end_date="2020-12-31"
+            )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+def test_aborts_on_unsupported_dataset():
+    with pytest.raises(ValueError, match="dataset"):
+        _download_data_stambaugh_yuan(dataset="weekly")
+
+
+def test_returns_empty_dataframe_after_download_failure():
+    with patch(
+        "tidyfinance.download_open_source.pd.read_csv",
+        side_effect=Exception("download failure"),
+    ):
+        with pytest.warns(UserWarning, match="Returning an empty dataset"):
+            result = _download_data_stambaugh_yuan()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 0
+
+
+if __name__ == "__main__":
+    # Run all tests
+    pytest.main([__file__])

--- a/tests/test_supported_datasets.py
+++ b/tests/test_supported_datasets.py
@@ -174,6 +174,7 @@ def test_parse_type_hf_prefix():
         ("fred", "FRED"),
         ("stock_prices", "Stock Prices"),
         ("osap", "Open Source Asset Pricing"),
+        ("jkp", "Global Factor Data"),
     ],
 )
 def test_parse_type_simple_domain(simple, canonical):
@@ -189,10 +190,17 @@ def test_parse_type_unknown_raises():
 
 
 @pytest.mark.parametrize(
-    "simple", ["constituents", "fred", "stock_prices", "osap"]
+    "simple", ["constituents", "fred", "stock_prices", "osap", "jkp"]
 )
 def test_is_legacy_type_false_for_simple_domains(simple):
     assert _is_legacy_type(simple) is False
+
+
+@pytest.mark.parametrize("other_type", ["liquidity", "mispricing"])
+def test_is_legacy_type_false_for_other_domain_specific_types(other_type):
+    # 'liquidity' (Pastor-Stambaugh) and 'mispricing' (Stambaugh-Yuan)
+    # have no short legacy alias and must not be treated as legacy.
+    assert _is_legacy_type(other_type) is False
 
 
 def test_is_legacy_type_true_for_ff_type():
@@ -232,6 +240,9 @@ def test_is_legacy_type_false_for_unknown_string():
         "FRED",
         "Stock Prices",
         "Open Source Asset Pricing",
+        "Global Factor Data",
+        "Pastor-Stambaugh",
+        "Stambaugh-Yuan",
         "Tidy Finance",
     ],
 )
@@ -262,6 +273,7 @@ def test_check_supported_domain_rejects_unknown():
         ("fred", "FRED"),
         ("stock_prices", "Stock Prices"),
         ("osap", "Open Source Asset Pricing"),
+        ("jkp", "Global Factor Data"),
         ("tidyfinance", "Tidy Finance"),
     ],
 )

--- a/tidyfinance/__init__.py
+++ b/tidyfinance/__init__.py
@@ -87,6 +87,7 @@ _BACKEND_WRAPPED = (
     "download_data",
     "list_supported_datasets",
     "list_supported_indexes",
+    "list_supported_jkp_factors",
     "process_trace_data",
 )
 for _name in _BACKEND_WRAPPED:

--- a/tidyfinance/download.py
+++ b/tidyfinance/download.py
@@ -9,12 +9,18 @@ from .download_open_source import (
     _download_data_factors_ff,
     _download_data_factors_q,
     _download_data_fred,
+    _download_data_jkp,
     _download_data_macro_predictors,
     _download_data_osap,
+    _download_data_pastor_stambaugh,
+    _download_data_stambaugh_yuan,
     _download_data_stock_prices,
 )
 from .download_pseudo import _simulate_pseudo_data
-from .download_tidy_finance import _download_data_huggingface, _download_data_risk_free
+from .download_tidy_finance import (
+    _download_data_huggingface,
+    _download_data_risk_free,
+)
 from .download_wrds import _download_data_wrds
 from .supported_datasets import (
     _check_supported_domain,
@@ -48,9 +54,11 @@ def download_data(
         canonical names returned by 'list_supported_datasets()':
         'Fama-French', 'Global Q', 'Goyal-Welch', 'WRDS', 'Pseudo Data',
         'Index Constituents', 'FRED', 'Stock Prices',
-        'Open Source Asset Pricing', 'Tidy Finance'. The previous
-        short names (e.g. 'famafrench', 'wrds', 'pseudo') are still
-        accepted but deprecated and will be removed in a future release.
+        'Open Source Asset Pricing', 'Global Factor Data',
+        'Pastor-Stambaugh', 'Stambaugh-Yuan', 'Tidy Finance'. The
+        previous short names (e.g. 'famafrench', 'wrds', 'pseudo') are
+        still accepted but deprecated and will be removed in a future
+        release.
     dataset : str, optional
         The specific dataset to download within the domain.
     start_date : str, optional
@@ -70,7 +78,11 @@ def download_data(
         Additional arguments passed to specific download functions
         depending on 'domain'. For instance, if 'domain' is
         'Index Constituents', arguments are passed to
-        '_download_data_constituents'. If 'domain' is 'Tidy Finance' and
+        '_download_data_constituents'. If 'domain' is
+        'Global Factor Data', the 'dataset' argument and arguments
+        such as 'region', 'factors', 'classification', 'frequency',
+        and 'weighting' are passed to '_download_data_jkp'. If
+        'domain' is 'Tidy Finance' and
         'dataset' is 'factor_library', arguments are either filter
         inputs (e.g., 'sorting_variable', 'rebalancing', 'fill_all') or
         an explicit 'ids' vector that bypasses the grid filter and
@@ -101,6 +113,19 @@ def download_data(
     download_data('Index Constituents', index='DAX')
     download_data('FRED', series=['GDP', 'CPIAUCNS'])
     download_data('Stock Prices', symbols=['AAPL', 'MSFT'])
+    download_data(
+        'Global Factor Data',
+        region='usa',
+        factors='mkt',
+        start_date='2000-01-01',
+        end_date='2020-12-31',
+    )
+    download_data(
+        'Pastor-Stambaugh', '2020-01-01', '2020-12-31'
+    )
+    download_data(
+        'Stambaugh-Yuan', 'monthly', '2015-01-01', '2016-12-31'
+    )
     download_data(
         'Tidy Finance', 'risk_free', '2020-01-01', '2020-12-31'
     )
@@ -174,6 +199,24 @@ def download_data(
     elif domain == "Open Source Asset Pricing":
         processed_data = _download_data_osap(
             start_date=start_date, end_date=end_date, **kwargs
+        )
+    elif domain == "Global Factor Data":
+        processed_data = _download_data_jkp(
+            dataset=dataset if dataset is not None else "factors",
+            start_date=start_date,
+            end_date=end_date,
+            **kwargs,
+        )
+    elif domain == "Pastor-Stambaugh":
+        processed_data = _download_data_pastor_stambaugh(
+            start_date=start_date, end_date=end_date, **kwargs
+        )
+    elif domain == "Stambaugh-Yuan":
+        processed_data = _download_data_stambaugh_yuan(
+            dataset=dataset if dataset is not None else "monthly",
+            start_date=start_date,
+            end_date=end_date,
+            **kwargs,
         )
     elif domain == "Tidy Finance":
         if dataset == "risk_free":

--- a/tidyfinance/download_open_source.py
+++ b/tidyfinance/download_open_source.py
@@ -10,7 +10,11 @@ import numpy as np
 import pandas as pd
 from curl_cffi import requests
 
-from ._internal import _get_random_user_agent, _transfrom_to_snake_case, _validate_dates
+from ._internal import (
+    _get_random_user_agent,
+    _transfrom_to_snake_case,
+    _validate_dates,
+)
 from .supported_datasets import (
     _check_supported_dataset_ff,
     _determine_frequency_ff,
@@ -47,11 +51,14 @@ def get_available_famafrench_datasets():
     response = requests.get(f"{ff_url}data_library.html")
     root = document_fromstring(response.content)
 
-    datasets = [e.attrib["href"] for e in root.findall(".//a") if "href" in e.attrib]
+    datasets = [
+        e.attrib["href"] for e in root.findall(".//a") if "href" in e.attrib
+    ]
     datasets = [
         dataset_i
         for dataset_i in datasets
-        if dataset_i.startswith(ff_url_prefix) and dataset_i.endswith(ff_url_suffix)
+        if dataset_i.startswith(ff_url_prefix)
+        and dataset_i.endswith(ff_url_suffix)
     ]
     datasets_list = list(
         map(lambda x: x[len(ff_url_prefix) : -len(ff_url_suffix)], datasets)
@@ -282,14 +289,18 @@ def _download_data_factors_ff(
                 raw_downloaded.reset_index()
                 .rename(
                     columns=lambda x: (
-                        x.lower().replace("-rf", "_excess").replace("rf", "risk_free")
+                        x.lower()
+                        .replace("-rf", "_excess")
+                        .replace("rf", "risk_free")
                         if isinstance(x, str)
                         else x
                     )
                 )
                 .apply(
                     lambda x: (
-                        x.replace([-99.99, -999], np.nan) if x.name != "date" else x
+                        x.replace([-99.99, -999], np.nan)
+                        if x.name != "date"
+                        else x
                     )
                 )
             )
@@ -405,16 +416,22 @@ def _download_data_factors_q(
         )
     try:
         raw_data = (
-            pd.read_csv(f"{url}{dataset}.csv", engine="python", on_bad_lines="skip")
+            pd.read_csv(
+                f"{url}{dataset}.csv", engine="python", on_bad_lines="skip"
+            )
             .rename(columns=lambda x: x.lower().replace("r_", ""))
             .rename(columns={"f": "risk_free", "mkt": "mkt_excess"})
         )
     except Exception as e:
-        raise ValueError(f"Could not download or parse dataset '{dataset}': {e}") from e
+        raise ValueError(
+            f"Could not download or parse dataset '{dataset}': {e}"
+        ) from e
 
     if "monthly" in dataset:
         raw_data = raw_data.assign(
-            date=pd.to_datetime(dict(year=raw_data.year, month=raw_data.month, day=1))
+            date=pd.to_datetime(
+                dict(year=raw_data.year, month=raw_data.month, day=1)
+            )
         ).drop(columns=["year", "month"])
     if "weekly" in dataset:
         raw_data = raw_data.assign(
@@ -559,7 +576,9 @@ def _download_data_macro_predictors(
             date=lambda x: pd.to_datetime(
                 x["yyyyq"].astype(str).str[:4]
                 + "-"
-                + (x["yyyyq"].astype(str).str[4].astype(int) * 3 - 2).astype(str)
+                + (x["yyyyq"].astype(str).str[4].astype(int) * 3 - 2).astype(
+                    str
+                )
                 + "-01"
             )
         ).drop(columns=["yyyyq"])
@@ -584,7 +603,9 @@ def _download_data_macro_predictors(
     ).assign(
         IndexDiv=lambda df: df["Index"] + df["D12"],
         logret=lambda df: (
-            df["IndexDiv"].apply(lambda x: np.nan if pd.isna(x) else np.log(x)).diff()
+            df["IndexDiv"]
+            .apply(lambda x: np.nan if pd.isna(x) else np.log(x))
+            .diff()
         ),
         rp_div=lambda df: df["logret"].shift(-1) - df["Rfree"],
         log_d12=lambda df: df["D12"].apply(
@@ -599,7 +620,9 @@ def _download_data_macro_predictors(
         ),
         dy=lambda df: (
             df["log_d12"]
-            - df["Index"].shift(1).apply(lambda x: np.nan if pd.isna(x) else np.log(x))
+            - df["Index"]
+            .shift(1)
+            .apply(lambda x: np.nan if pd.isna(x) else np.log(x))
         ),
         ep=lambda df: (
             df["log_e12"]
@@ -713,7 +736,9 @@ def _download_data_constituents(
             f"Supported indexes: {', '.join(supported_indexes['index'])}"
         )
 
-    url = supported_indexes.loc[supported_indexes["index"] == index, "url"].values[0]
+    url = supported_indexes.loc[
+        supported_indexes["index"] == index, "url"
+    ].values[0]
     skip_rows = supported_indexes.loc[
         supported_indexes["index"] == index, "skip"
     ].values[0]
@@ -907,7 +932,11 @@ def _download_data_fred(
                                 x[x.columns[x.columns.str.contains("date")][0]]
                             ),
                             value=lambda x: pd.to_numeric(
-                                x[x.columns[~x.columns.str.contains("date")][0]],
+                                x[
+                                    x.columns[~x.columns.str.contains("date")][
+                                        0
+                                    ]
+                                ],
                                 errors="coerce",
                             ),
                             series=s,
@@ -933,9 +962,9 @@ def _download_data_fred(
 
     fred_data = pd.concat(fred_data, ignore_index=True)
     if start_date and end_date:
-        fred_data = fred_data.query("@start_date <= date <= @end_date").reset_index(
-            drop=True
-        )
+        fred_data = fred_data.query(
+            "@start_date <= date <= @end_date"
+        ).reset_index(drop=True)
     return fred_data
 
 
@@ -986,7 +1015,9 @@ def _download_data_stock_prices(
     ):
         raise ValueError("symbols must be a list of stock symbols (strings).")
 
-    start_date, end_date = _validate_dates(start_date, end_date, use_default_range=True)
+    start_date, end_date = _validate_dates(
+        start_date, end_date, use_default_range=True
+    )
 
     start_timestamp = int(start_date.timestamp())
     end_timestamp = int(end_date.timestamp())
@@ -1002,7 +1033,9 @@ def _download_data_stock_prices(
 
         headers = {"User-Agent": _get_random_user_agent()}
         try:
-            response = requests.get(url, impersonate="chrome120", headers=headers)
+            response = requests.get(
+                url, impersonate="chrome120", headers=headers
+            )
         except Exception:
             response = requests.get(url, impersonate="chrome120")
 
@@ -1019,7 +1052,9 @@ def _download_data_stock_prices(
 
             timestamps = raw_data[0]["timestamp"]
             indicators = raw_data[0]["indicators"]["quote"][0]
-            adjusted_close = raw_data[0]["indicators"]["adjclose"][0]["adjclose"]
+            adjusted_close = raw_data[0]["indicators"]["adjclose"][0][
+                "adjclose"
+            ]
 
             df_symbol = pd.DataFrame().assign(
                 date=pd.to_datetime(
@@ -1144,7 +1179,9 @@ def _download_data_osap(
             .dt.start_time
         )
 
-    raw_data.columns = [_transfrom_to_snake_case(col) for col in raw_data.columns]
+    raw_data.columns = [
+        _transfrom_to_snake_case(col) for col in raw_data.columns
+    ]
 
     # All columns except the date are long-short returns in percent, so
     # scale them to plain numeric (decimal) returns.
@@ -1155,3 +1192,762 @@ def _download_data_osap(
         raw_data = raw_data.query("@start_date <= date <= @end_date")
 
     return raw_data.reset_index(drop=True)
+
+
+def _download_data_pastor_stambaugh(
+    start_date: str = None,
+    end_date: str = None,
+    url: str = (
+        "https://faculty.chicagobooth.edu/-/media/faculty/lubos-pastor/"
+        "data/liq_data_1962_2025.txt"
+    ),
+) -> pd.DataFrame:
+    """
+    Download and process Pastor-Stambaugh liquidity factors.
+
+    Downloads and processes the liquidity factor data of Pastor and
+    Stambaugh (2003) from
+    `Pastor's data library
+    <https://faculty.chicagobooth.edu/lubos-pastor/data>`_. The source
+    is a whitespace-delimited text file whose header lines start with
+    a percent sign. The function reads the three liquidity series,
+    aligns the monthly date to the beginning of the month, and
+    optionally filters the data based on a provided date range.
+
+    The series are already expressed as plain numeric (decimal) values
+    in the source data, so no rescaling is applied. The traded
+    liquidity factor is only available from 1968 onward; earlier
+    observations are coded as -99 in the source file and are returned
+    as NaN.
+
+    Parameters
+    ----------
+    start_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the start date for the data. If not provided, the full
+        dataset is returned.
+    end_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the end date for the data. If not provided, the full dataset
+        is returned.
+    url : str, optional
+        The URL of the liquidity data file. Because the file name
+        embeds the last year of data, the default points to the most
+        recent file known at release time; override it when a newer
+        file becomes available.
+
+    Returns
+    -------
+    pd.DataFrame
+        A data frame with the columns 'date' (aligned to the
+        beginning of the month), 'agg_liq' (levels of aggregate
+        liquidity), 'innov_liq' (innovations in aggregate liquidity,
+        the non-traded liquidity factor), and 'traded_liq' (the traded
+        liquidity factor LIQ_V), filtered by the specified date range
+        if 'start_date' and 'end_date' are provided.
+
+    References
+    ----------
+    Pastor, L., and Stambaugh, R. F. (2003). Liquidity risk and
+    expected stock returns. Journal of Political Economy, 111(3),
+    642-685. https://doi.org/10.1086/374184
+
+    Examples
+    --------
+    ```python
+    from tidyfinance import download_data_pastor_stambaugh
+    pastor_stambaugh = download_data_pastor_stambaugh(
+        start_date='2020-01-01', end_date='2020-12-31'
+    )
+    ```
+    """
+    start_date, end_date = _validate_dates(start_date, end_date)
+
+    try:
+        raw_data = pd.read_csv(
+            url,
+            sep=r"\s+",
+            comment="%",
+            header=None,
+            names=["month", "agg_liq", "innov_liq", "traded_liq"],
+        )
+    except Exception:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return pd.DataFrame()
+
+    if raw_data.empty:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return raw_data
+
+    # The traded factor is coded -99 before it becomes available (1968).
+    processed_data = raw_data.assign(
+        date=lambda x: pd.to_datetime(x["month"].astype(str), format="%Y%m")
+    )
+    liquidity_columns = ["agg_liq", "innov_liq", "traded_liq"]
+    processed_data[liquidity_columns] = processed_data[
+        liquidity_columns
+    ].replace(-99, np.nan)
+    processed_data = processed_data[["date", *liquidity_columns]]
+
+    if start_date and end_date:
+        processed_data = processed_data.query(
+            "@start_date <= date <= @end_date"
+        )
+
+    return processed_data.reset_index(drop=True)
+
+
+def _download_data_stambaugh_yuan(
+    dataset: str = "monthly",
+    start_date: str = None,
+    end_date: str = None,
+    url: str = "https://finance.wharton.upenn.edu/~stambaug/",
+) -> pd.DataFrame:
+    """
+    Download and process Stambaugh-Yuan mispricing factors.
+
+    Downloads and processes the mispricing factor data of Stambaugh
+    and Yuan (2017) from
+    `Stambaugh's data library
+    <https://finance.wharton.upenn.edu/~stambaug/>`_. The four-factor
+    model (M4) combines the market and size factors with two
+    mispricing factors, 'mgmt' (management) and 'perf' (performance).
+    The function downloads the requested frequency, aligns the date,
+    renames the columns to the package conventions, and optionally
+    filters the data based on a provided date range.
+
+    Returns are already expressed as plain numeric (decimal) values in
+    the source data, so no rescaling is applied. The source files
+    currently end in December 2016; a requested date range that lies
+    entirely outside the available data emits a warning and returns
+    an empty data frame.
+
+    Parameters
+    ----------
+    dataset : str, default 'monthly'
+        The data frequency to download, either 'monthly' or 'daily'.
+    start_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the start date for the data. If not provided, the full
+        dataset is returned.
+    end_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the end date for the data. If not provided, the full dataset
+        is returned.
+    url : str, optional
+        The base URL from which to download the dataset files. The
+        file name ('M4.csv' or 'M4d.csv') is appended based on
+        'dataset'.
+
+    Returns
+    -------
+    pd.DataFrame
+        A data frame with the columns 'date' (aligned to the
+        beginning of the month for monthly data), 'mkt_excess' (the
+        market excess return), 'smb' (size), 'mgmt' (the management
+        mispricing factor), 'perf' (the performance mispricing
+        factor), and 'risk_free' (the risk-free rate). All returns are
+        plain numeric (decimal) values, filtered by the specified
+        date range if 'start_date' and 'end_date' are provided.
+
+    References
+    ----------
+    Stambaugh, R. F., and Yuan, Y. (2017). Mispricing factors. Review
+    of Financial Studies, 30(4), 1270-1315.
+    https://doi.org/10.1093/rfs/hhw107
+
+    Examples
+    --------
+    ```python
+    from tidyfinance import download_data_stambaugh_yuan
+    download_data_stambaugh_yuan(
+        start_date='2015-01-01', end_date='2016-12-31'
+    )
+    download_data_stambaugh_yuan(
+        dataset='daily', start_date='2016-01-01', end_date='2016-12-31'
+    )
+    ```
+    """
+    if dataset not in ("monthly", "daily"):
+        raise ValueError("'dataset' must be 'monthly' or 'daily'.")
+
+    start_date, end_date = _validate_dates(start_date, end_date)
+
+    file = "M4d.csv" if dataset == "daily" else "M4.csv"
+
+    try:
+        raw_data = pd.read_csv(f"{url}{file}")
+    except Exception:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return pd.DataFrame()
+
+    if raw_data.empty:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return raw_data
+
+    # The monthly file keys rows by YYYYMM, the daily file by YYYYMMDD.
+    if dataset == "daily":
+        processed_data = raw_data.assign(
+            date=lambda x: pd.to_datetime(
+                x["DATE"].astype(str), format="%Y%m%d"
+            )
+        )
+    else:
+        processed_data = raw_data.assign(
+            date=lambda x: pd.to_datetime(
+                x["YYYYMM"].astype(str), format="%Y%m"
+            )
+        )
+
+    processed_data = processed_data.rename(
+        columns={
+            "MKTRF": "mkt_excess",
+            "SMB": "smb",
+            "MGMT": "mgmt",
+            "PERF": "perf",
+            "RF": "risk_free",
+        }
+    )[["date", "mkt_excess", "smb", "mgmt", "perf", "risk_free"]]
+
+    if start_date and end_date:
+        filtered_data = processed_data.query("@start_date <= date <= @end_date")
+
+        if filtered_data.empty:
+            available_start = processed_data["date"].min().date()
+            available_end = processed_data["date"].max().date()
+            warnings.warn(
+                "The requested date range lies outside the available "
+                "Stambaugh-Yuan data. Available data range: "
+                f"{available_start} to {available_end}.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        processed_data = filtered_data
+
+    return processed_data.reset_index(drop=True)
+
+
+_JKP_BASE_URL = "https://jkpfactors-data.s3.amazonaws.com"
+
+
+def _fetch_jkp_availability(max_tries: int = 3) -> dict:
+    """
+    Fetch the Global Factor Data availability manifest.
+
+    Downloads and parses the JSON availability manifest that lists the
+    regions, factors, and frequency restrictions offered by
+    `Global Factor Data <https://jkpfactors.com/data>`_.
+
+    Parameters
+    ----------
+    max_tries : int, default 3
+        Number of download attempts before giving up.
+
+    Returns
+    -------
+    dict
+        The parsed manifest, including the 'factors', 'portfolios',
+        and 'industry' keys (each mapping region codes to the
+        available selectors) and 'factors_monthly_only' (region codes
+        mapped to factors available at monthly frequency only).
+
+    Raises
+    ------
+    Exception
+        If the manifest could not be downloaded after 'max_tries'
+        attempts.
+    """
+    url = f"{_JKP_BASE_URL}/public/availability.json"
+    headers = {"User-Agent": _get_random_user_agent()}
+    last_error = None
+    for _ in range(max_tries):
+        try:
+            response = requests.get(
+                url, headers=headers, timeout=60, impersonate="chrome120"
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            last_error = e
+    raise last_error
+
+
+def _validate_jkp_selection(
+    availability: dict,
+    dataset: str,
+    region: str,
+    selector: str,
+    frequency: str,
+) -> None:
+    """
+    Validate a Global Factor Data selection against the manifest.
+
+    Parameters
+    ----------
+    availability : dict
+        The manifest returned by '_fetch_jkp_availability'.
+    dataset : str
+        One of 'factors', 'portfolios', or 'industry'.
+    region : str
+        The region or country code to validate.
+    selector : str
+        The factor code, theme, or industry classification to
+        validate.
+    frequency : str
+        Either 'monthly' or 'daily'.
+
+    Raises
+    ------
+    ValueError
+        If 'region' is not available for 'dataset', if 'selector' is
+        not available for 'region', or if 'selector' is only
+        available at monthly frequency but 'frequency' is 'daily'.
+    """
+    regions = list(availability.get(dataset, {}).keys())
+    if region not in regions:
+        raise ValueError(
+            f"Unsupported region: {region!r} for dataset {dataset!r}. "
+            "Use list_supported_jkp_factors(dataset="
+            f"{dataset!r}) to see valid regions."
+        )
+
+    available = availability[dataset][region]
+    if selector not in available:
+        raise ValueError(
+            f"Unsupported selection {selector!r} for region {region!r} "
+            f"in dataset {dataset!r}. Use list_supported_jkp_factors("
+            f"{region!r}, {dataset!r}) to see valid values."
+        )
+
+    if dataset == "factors":
+        monthly_only = availability.get("factors_monthly_only", {}).get(
+            region, []
+        )
+        if frequency == "daily" and selector in monthly_only:
+            raise ValueError(
+                f"{selector!r} is only available at monthly frequency "
+                f"for region {region!r}. Set frequency='monthly'."
+            )
+
+
+def _build_jkp_url(
+    dataset: str, region: str, selector: str, frequency: str, weighting: str
+) -> str:
+    """
+    Build the S3 download URL for a Global Factor Data archive.
+
+    Parameters
+    ----------
+    dataset : str
+        One of 'factors', 'portfolios', or 'industry'.
+    region : str
+        The region or country code.
+    selector : str
+        The factor code, theme, or industry classification.
+    frequency : str
+        Either 'monthly' or 'daily'. Ignored for 'industry', which is
+        only published at monthly frequency.
+    weighting : str
+        The portfolio weighting scheme.
+
+    Returns
+    -------
+    str
+        The URL of the zipped CSV archive.
+    """
+
+    def b(x: str) -> str:
+        # The S3 object keys wrap each selector in literal square
+        # brackets, which are URL-encoded as %5B and %5D.
+        return f"%5B{x}%5D"
+
+    if dataset == "factors":
+        return (
+            f"{_JKP_BASE_URL}/public/"
+            f"{b(region)}_{b(selector)}_{b(frequency)}_{b(weighting)}.zip"
+        )
+    elif dataset == "portfolios":
+        return (
+            f"{_JKP_BASE_URL}/public/portfolios/"
+            f"{b(region)}_{b(selector)}_{b(frequency)}_{b(weighting)}.zip"
+        )
+    else:
+        # The industry dataset is only published at monthly frequency.
+        return (
+            f"{_JKP_BASE_URL}/public/industry/"
+            f"{b(region)}_{b(selector)}_{b('monthly')}_{b(weighting)}.zip"
+        )
+
+
+def _build_jkp_reference_url(dataset: str, frequency: str) -> str:
+    """
+    Build the S3 download URL for a Global Factor Data reference file.
+
+    Parameters
+    ----------
+    dataset : str
+        Either 'nyse_cutoffs' or 'return_cutoffs'.
+    frequency : str
+        Either 'monthly' or 'daily'. Selects between the monthly and
+        daily 'return_cutoffs' file; ignored for 'nyse_cutoffs'.
+
+    Returns
+    -------
+    str
+        The URL of the plain CSV reference file.
+    """
+    base_url = f"{_JKP_BASE_URL}/public/other"
+
+    if dataset == "nyse_cutoffs":
+        return f"{base_url}/nyse_cutoffs.csv"
+    elif frequency == "daily":
+        return f"{base_url}/return_cutoffs_daily.csv"
+    else:
+        return f"{base_url}/return_cutoffs.csv"
+
+
+def _download_jkp_file(url: str, max_tries: int = 5) -> pd.DataFrame:
+    """
+    Download and read a zipped Global Factor Data CSV file.
+
+    Parameters
+    ----------
+    url : str
+        URL of the zipped CSV archive.
+    max_tries : int, default 5
+        Number of download attempts before giving up.
+
+    Returns
+    -------
+    pd.DataFrame
+        The first CSV file found in the archive.
+
+    Raises
+    ------
+    Exception
+        If the archive could not be downloaded after 'max_tries'
+        attempts.
+    ValueError
+        If no CSV file is found in the downloaded archive.
+    """
+    headers = {"User-Agent": _get_random_user_agent()}
+    last_error = None
+    response = None
+    for _ in range(max_tries):
+        try:
+            response = requests.get(
+                url, headers=headers, timeout=180, impersonate="chrome120"
+            )
+            response.raise_for_status()
+            break
+        except Exception as e:
+            last_error = e
+            response = None
+    if response is None:
+        raise last_error
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
+        if not csv_names:
+            raise ValueError("No CSV file found in the downloaded archive.")
+        with zf.open(csv_names[0]) as f:
+            return pd.read_csv(f, na_values=["na"])
+
+
+def _download_jkp_csv(url: str, max_tries: int = 5) -> pd.DataFrame:
+    """
+    Download and read a plain Global Factor Data CSV file.
+
+    Parameters
+    ----------
+    url : str
+        URL of the plain CSV file.
+    max_tries : int, default 5
+        Number of download attempts before giving up.
+
+    Returns
+    -------
+    pd.DataFrame
+        The parsed CSV file.
+
+    Raises
+    ------
+    Exception
+        If the file could not be downloaded after 'max_tries' attempts.
+    """
+    headers = {"User-Agent": _get_random_user_agent()}
+    last_error = None
+    for _ in range(max_tries):
+        try:
+            response = requests.get(
+                url, headers=headers, timeout=180, impersonate="chrome120"
+            )
+            response.raise_for_status()
+            return pd.read_csv(io.StringIO(response.text), na_values=["na"])
+        except Exception as e:
+            last_error = e
+    raise last_error
+
+
+def _process_jkp_data(
+    data: pd.DataFrame,
+    date_col: str,
+    frequency: str,
+    start_date,
+    end_date,
+) -> pd.DataFrame:
+    """
+    Normalize dates and filter a Global Factor Data table.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Raw data with a date-like column named 'date_col'.
+    date_col : str
+        Name of the date column in 'data'. Renamed to 'date' if it
+        differs.
+    frequency : str
+        Either 'monthly' or 'daily'. Monthly dates are aligned to the
+        beginning of the month.
+    start_date, end_date : Timestamp or None
+        Filter bounds. No filtering is applied if either is None.
+
+    Returns
+    -------
+    pd.DataFrame
+        The processed data, filtered by the specified date range if
+        both 'start_date' and 'end_date' are provided.
+    """
+    data = data.copy()
+    if date_col != "date":
+        data = data.rename(columns={date_col: "date"})
+
+    data["date"] = pd.to_datetime(data["date"])
+
+    if frequency == "monthly":
+        data["date"] = data["date"].dt.to_period("M").dt.start_time
+
+    if start_date is not None and end_date is not None:
+        data = data.query("@start_date <= date <= @end_date")
+
+    return data.reset_index(drop=True)
+
+
+def _download_data_jkp(
+    dataset: str = "factors",
+    region: str = "usa",
+    factors: str = "all_factors",
+    classification: str = "gics",
+    frequency: str = "monthly",
+    weighting: str = "vw_cap",
+    start_date: str = None,
+    end_date: str = None,
+) -> pd.DataFrame:
+    """
+    Download and process Global Factor Data.
+
+    Downloads and processes data from
+    `Global Factor Data <https://jkpfactors.com/data>`_, the public data
+    library accompanying Jensen, Kelly, and Pedersen (2023). The data
+    are stored as zipped CSV files (and a few plain CSV reference
+    files) in a public AWS S3 bucket. For the factor, portfolio, and
+    industry products the function validates the requested selection
+    against the library's live availability manifest, then downloads
+    the matching archive, unzips it, aligns monthly dates to the
+    beginning of the month, and optionally filters by a date range.
+
+    Returns are already expressed as plain numeric (decimal) values in
+    the source data, so no rescaling is applied. The data are licensed
+    under CC BY-NC 4.0 (non-commercial use).
+
+    Parameters
+    ----------
+    dataset : str, default 'factors'
+        The Global Factor Data product to download, one of:
+        'factors' (characteristic-managed portfolio returns),
+        'portfolios' (the underlying low/middle/high portfolios that
+        make up each long-short factor), 'industry' (industry
+        returns), 'nyse_cutoffs' (NYSE size breakpoints), or
+        'return_cutoffs' (return winsorization cutoffs).
+    region : str, default 'usa'
+        The region or country to download, using the codes from the
+        availability manifest (e.g., 'usa', 'world', 'developed',
+        'emerging', or an ISO-3 country code such as 'jpn'). Ignored
+        for the reference datasets 'nyse_cutoffs' and
+        'return_cutoffs'. Call 'list_supported_jkp_factors' to see the
+        available regions.
+    factors : str, default 'all_factors'
+        The factor content for the 'factors' and 'portfolios'
+        datasets. For 'factors': 'mkt' (the market factor),
+        'all_factors' (all factors), 'all_themes' (all themes), a
+        single theme (e.g., 'value', 'momentum'), or a single factor
+        code (e.g., 'be_me', 'ret_12_1'). For 'portfolios': a single
+        factor code. Call 'list_supported_jkp_factors(region, dataset)'
+        to see the values available for a region.
+    classification : str, default 'gics'
+        The industry classification for the 'industry' dataset,
+        either 'gics' or 'ff49' (Fama-French 49 industries).
+    frequency : str, default 'monthly'
+        The data frequency, either 'monthly' or 'daily'. The
+        'industry' dataset is only available at monthly frequency.
+        For 'return_cutoffs', the frequency selects the monthly or
+        daily cutoff file.
+    weighting : str, default 'vw_cap'
+        The portfolio weighting scheme: 'vw_cap' (capped
+        value-weighted), 'vw' (value-weighted), or 'ew'
+        (equal-weighted). Ignored for the reference datasets.
+    start_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the start date for the data. If not provided, the full
+        dataset is returned.
+    end_date : str, optional
+        A character string or date in 'YYYY-MM-DD' format specifying
+        the end date for the data. If not provided, the full dataset
+        is returned.
+
+    Returns
+    -------
+    pd.DataFrame
+        A data frame with the processed data. The 'date' column is
+        aligned to the beginning of the month for monthly data, and
+        all returns are plain numeric (decimal) values. The remaining
+        columns depend on 'dataset': the 'factors' data carry
+        'location', 'name', 'freq', 'weighting', 'direction',
+        'n_stocks', 'n_stocks_min', and 'ret'; the 'portfolios' data
+        add a 'pf' portfolio identifier; the 'industry' data carry the
+        classification code alongside 'ret'; and the reference
+        datasets carry breakpoint or cutoff columns.
+
+    References
+    ----------
+    Jensen, T. I., Kelly, B. T., and Pedersen, L. H. (2023). Is there a
+    replication crisis in finance? Journal of Finance, 78(5),
+    2465-2518. https://doi.org/10.1111/jofi.13249
+
+    Examples
+    --------
+    ```python
+    from tidyfinance import download_data_jkp
+    download_data_jkp(
+        region='usa', factors='mkt',
+        start_date='2000-01-01', end_date='2020-12-31',
+    )
+    download_data_jkp(
+        dataset='portfolios', region='usa', factors='be_me',
+        start_date='2000-01-01', end_date='2020-12-31',
+    )
+    download_data_jkp(dataset='industry', region='usa', classification='gics')
+    download_data_jkp(dataset='nyse_cutoffs')
+    ```
+    """
+    supported_datasets = (
+        "factors",
+        "portfolios",
+        "industry",
+        "nyse_cutoffs",
+        "return_cutoffs",
+    )
+    if dataset not in supported_datasets:
+        raise ValueError(
+            f"Unsupported dataset: {dataset!r}. "
+            f"Supported datasets: {', '.join(supported_datasets)}."
+        )
+
+    if frequency not in ("monthly", "daily"):
+        raise ValueError("'frequency' must be 'monthly' or 'daily'.")
+
+    start_date, end_date = _validate_dates(start_date, end_date)
+
+    # Reference datasets are plain CSV files that need neither manifest
+    # validation, weighting, nor a region selection.
+    if dataset in ("nyse_cutoffs", "return_cutoffs"):
+        url = _build_jkp_reference_url(dataset, frequency)
+        try:
+            raw_data = _download_jkp_csv(url)
+        except Exception:
+            raw_data = pd.DataFrame()
+
+        if raw_data.empty:
+            warnings.warn(
+                "Returning an empty dataset due to a download or "
+                "parsing failure.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return raw_data
+
+        return _process_jkp_data(
+            raw_data,
+            date_col="eom",
+            frequency="monthly",
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    if weighting not in ("vw_cap", "vw", "ew"):
+        raise ValueError("'weighting' must be one of 'vw_cap', 'vw', 'ew'.")
+
+    if dataset == "industry" and frequency == "daily":
+        raise ValueError(
+            "The 'industry' dataset is only available at monthly "
+            "frequency. Set frequency='monthly'."
+        )
+
+    try:
+        availability = _fetch_jkp_availability()
+    except Exception:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return pd.DataFrame()
+
+    selector = classification if dataset == "industry" else factors
+    _validate_jkp_selection(availability, dataset, region, selector, frequency)
+
+    url = _build_jkp_url(dataset, region, selector, frequency, weighting)
+
+    try:
+        raw_data = _download_jkp_file(url)
+    except Exception:
+        raw_data = pd.DataFrame()
+
+    if raw_data.empty:
+        warnings.warn(
+            "Returning an empty dataset due to a download or parsing failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return raw_data
+
+    data_frequency = "monthly" if dataset == "industry" else frequency
+    processed_data = _process_jkp_data(
+        raw_data,
+        date_col="date",
+        frequency=data_frequency,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    if dataset == "portfolios" and "pf" in processed_data.columns:
+        processed_data["pf"] = processed_data["pf"].astype(int)
+
+    return processed_data

--- a/tidyfinance/supported_datasets.py
+++ b/tidyfinance/supported_datasets.py
@@ -2066,6 +2066,21 @@ _OTHER_DATASETS = [
         "domain": "Open Source Asset Pricing",
     },
     {
+        "type": "jkp",
+        "dataset_name": "Global Factor Data",
+        "domain": "Global Factor Data",
+    },
+    {
+        "type": "liquidity",
+        "dataset_name": "Liquidity Factors",
+        "domain": "Pastor-Stambaugh",
+    },
+    {
+        "type": "mispricing",
+        "dataset_name": "Mispricing Factors",
+        "domain": "Stambaugh-Yuan",
+    },
+    {
         "type": "risk_free",
         "dataset_name": "Risk-Free Rate",
         "domain": "Tidy Finance",
@@ -2157,6 +2172,7 @@ _SIMPLE_DOMAINS: tuple[str, ...] = (
     "fred",
     "stock_prices",
     "osap",
+    "jkp",
 )
 
 
@@ -2172,6 +2188,9 @@ _SUPPORTED_DOMAINS: tuple[str, ...] = (
     "FRED",
     "Stock Prices",
     "Open Source Asset Pricing",
+    "Global Factor Data",
+    "Pastor-Stambaugh",
+    "Stambaugh-Yuan",
     "Tidy Finance",
 )
 
@@ -2192,6 +2211,7 @@ _DOMAIN_ALIASES: dict[str, str] = {
     "fred": "FRED",
     "stock_prices": "Stock Prices",
     "osap": "Open Source Asset Pricing",
+    "jkp": "Global Factor Data",
     "tidyfinance": "Tidy Finance",
 }
 
@@ -2330,7 +2350,10 @@ def _is_legacy_type(x: str) -> bool:
     would succeed on it and it is not one of the simple domain names
     listed in '_SIMPLE_DOMAINS' (those are already valid domains in
     their own right). 'Tidy Finance' domain 'other' datasets such as
-    'risk_free' or 'factor_library' are not treated as legacy either.
+    'risk_free' or 'factor_library' are not treated as legacy either,
+    nor are the 'liquidity' and 'mispricing' 'other' rows (the
+    'Pastor-Stambaugh' and 'Stambaugh-Yuan' domains have no short
+    legacy alias).
 
     Parameters
     ----------
@@ -2351,11 +2374,15 @@ def _is_legacy_type(x: str) -> bool:
     known_types.update(row["type"] for row in _Q_DATASETS)
     known_types.update(row["type"] for row in _MACRO_DATASETS)
     known_types.update(row["type"] for row in _WRDS_DATASETS)
-    # "other" rows that are NOT in the tidyfinance domain and NOT "osap"
+    # "other" rows that are NOT in the tidyfinance domain and are not
+    # one of the domains with their own simple-domain alias/"other" row
+    # ("osap", "jkp", "liquidity", "mispricing")
+    excluded_other_types = {"osap", "jkp", "liquidity", "mispricing"}
     known_types.update(
         row["type"]
         for row in _OTHER_DATASETS
-        if row["domain"] != "Tidy Finance" and row["type"] != "osap"
+        if row["domain"] != "Tidy Finance"
+        and row["type"] not in excluded_other_types
     )
 
     return x in known_types

--- a/tidyfinance/utilities.py
+++ b/tidyfinance/utilities.py
@@ -1,5 +1,6 @@
 """Utility functions module for tidyfinance."""
 
+import warnings
 import webbrowser
 
 import numpy as np
@@ -89,7 +90,9 @@ def create_summary_statistics(
     """
     # Check that all specified variables are numeric or boolean
     non_numeric_vars = [
-        var for var in variables if not pd.api.types.is_numeric_dtype(data[var].dtype)
+        var
+        for var in variables
+        if not pd.api.types.is_numeric_dtype(data[var].dtype)
     ]
     if non_numeric_vars:
         raise ValueError(
@@ -100,7 +103,9 @@ def create_summary_statistics(
     # Cast boolean columns to float so they survive `describe()`, which
     # drops bool dtype by default. The mean of the cast column then
     # equals the proportion of True in the original.
-    bool_cols = [v for v in variables if pd.api.types.is_bool_dtype(data[v].dtype)]
+    bool_cols = [
+        v for v in variables if pd.api.types.is_bool_dtype(data[v].dtype)
+    ]
     if bool_cols:
         data = data.copy()
         for c in bool_cols:
@@ -112,7 +117,9 @@ def create_summary_statistics(
 
     # Compute summary statistics using describe
     percentiles = (
-        [0.5] if not detail else [0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99]
+        [0.5]
+        if not detail
+        else [0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99]
     )
 
     if by:
@@ -228,6 +235,82 @@ def list_supported_indexes() -> pd.DataFrame:
         ),
     ]
     return pd.DataFrame(data, columns=["index", "url", "skip"])
+
+
+def list_supported_jkp_factors(
+    region: str = None, dataset: str = "factors"
+) -> pd.DataFrame:
+    """Return the regions and factors supported by Global Factor Data.
+
+    Queries the live availability manifest of
+    `Global Factor Data <https://jkpfactors.com/data>`_ and returns the
+    regions and selectors that can be passed to 'download_data_jkp'.
+
+    Parameters
+    ----------
+    region : str, optional
+        A region or country code. If provided, the function returns
+        the selectors (factor codes, or industry classifications when
+        'dataset="industry"') available for that region. If 'None'
+        (the default), it returns the available region codes.
+    dataset : str, default 'factors'
+        The Global Factor Data product to query, one of 'factors',
+        'portfolios', or 'industry'.
+
+    Returns
+    -------
+    pd.DataFrame
+        When 'region' is 'None', a data frame with a single 'region'
+        column listing the available region codes. When 'region' is
+        provided, a data frame with a 'region' column and a 'factor'
+        column listing the selectors (factor codes, or industry
+        classifications when 'dataset="industry"') available for that
+        region.
+
+    Examples
+    --------
+    ```python
+    from tidyfinance import list_supported_jkp_factors
+    list_supported_jkp_factors()
+    list_supported_jkp_factors('usa')
+    list_supported_jkp_factors('usa', dataset='portfolios')
+    ```
+    """
+    # Imported lazily to avoid a circular import: 'download_open_source'
+    # imports 'list_supported_indexes' from this module at load time.
+    from .download_open_source import _fetch_jkp_availability
+
+    supported_datasets = ("factors", "portfolios", "industry")
+    if dataset not in supported_datasets:
+        raise ValueError(
+            f"Unsupported dataset: {dataset!r}. "
+            f"Supported datasets: {', '.join(supported_datasets)}."
+        )
+
+    try:
+        availability = _fetch_jkp_availability()
+    except Exception:
+        warnings.warn(
+            "Returning an empty dataset due to download failure.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return pd.DataFrame({"region": []})
+
+    regions = list(availability.get(dataset, {}).keys())
+
+    if region is None:
+        return pd.DataFrame({"region": regions})
+
+    if region not in regions:
+        raise ValueError(
+            f"Unsupported region: {region!r}. Use "
+            "list_supported_jkp_factors() to see valid regions."
+        )
+
+    return pd.DataFrame(
+        {"region": region, "factor": availability[dataset][region]}
+    )
 
 
 def list_tidy_finance_chapters() -> list:

--- a/uv.lock
+++ b/uv.lock
@@ -2750,7 +2750,7 @@ wheels = [
 
 [[package]]
 name = "tidyfinance"
-version = "0.3.1.dev2"
+version = "0.3.1.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary
- Adds `download_data(domain="Global Factor Data", ...)` for factor/portfolio/industry returns and reference cutoff files from [Global Factor Data](https://jkpfactors.com/data) (Jensen, Kelly & Pedersen, 2023), validated against the library's live availability manifest, plus `list_supported_jkp_factors()` to list available regions/factors.
- Adds `download_data(domain="Pastor-Stambaugh", ...)` for the liquidity factors of Pastor and Stambaugh (2003).
- Adds `download_data(domain="Stambaugh-Yuan", ...)` for the mispricing factors of Stambaugh and Yuan (2017), with `dataset="monthly"|"daily"`.
- Mirrors the equivalent [r-tidyfinance PR](https://github.com/tidy-finance/r-tidyfinance/commit/7c028e28568d4bf3b9d7ec280afbcbd4d0167963), including matching docstrings/docs and ported test cases.
- Updates README, CHANGELOG, and bumps version to `0.3.1.dev3`.

## Test plan
- [x] `uv run pytest` — 634 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean on all touched files
- [x] Verified no test hits the network (mocked `requests`/`pd.read_csv` throughout)