### PR TITLE
feat: FRED-MD / FRED-QD (McCracken-Ng) datasets with tcode transforms and vintages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Added FRED-MD and FRED-QD macroeconomic databases:**
+  `download_data("FRED", "FRED-MD")` and `download_data("FRED", "FRED-QD")`
+  download the McCracken and Ng (2016, 2021) curated monthly / quarterly
+  macro panels as wide tables (one column per series). `transform=True`
+  applies each series' stationarity transform code (tcode). `vintage`
+  selects the current release (default), a specific `"YYYY-MM"` release, or
+  `"all"` — the full real-time panel across every archived vintage (recent
+  vintages are hosted individually; older ones are read from the St. Louis
+  Fed vintage archive zips), enabling leak-free point-in-time analysis.
 - **Added Global Factor Data, Pastor-Stambaugh, and Stambaugh-Yuan
   downloads:** `download_data("Global Factor Data")` downloads
   characteristic-managed portfolio returns, the underlying long-short

--- a/tests/test_download_data_fred_md.py
+++ b/tests/test_download_data_fred_md.py
@@ -1,0 +1,163 @@
+"""Tests for download_data_fred_md (FRED-MD / FRED-QD)."""
+
+import io
+import os
+import sys
+import zipfile
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from tidyfinance import download_data, list_supported_datasets  # noqa: E402
+from tidyfinance.download_open_source import (  # noqa: E402
+    _apply_fred_md_tcode,
+    _download_data_fred_md,
+)
+
+# A tiny FRED-MD-shaped CSV: header, the Transform: tcode row, then M/D/YYYY levels.
+_CSV = (
+    "sasdate,LEVELSER,LOGDIFFSER\n"
+    "Transform:,1,5\n"
+    "1/1/2020,100,100\n"
+    "2/1/2020,101,110\n"
+    "3/1/2020,102,121\n"
+)
+
+
+def _zip_bytes(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, text in files.items():
+            zf.writestr(name, text)
+    return buf.getvalue()
+
+
+def _fake_get(*, csv=_CSV, zip_files=None, fail_csv=False):
+    """Build a requests.get side effect: CSV text for .csv URLs, zip bytes for .zip URLs."""
+
+    def _get(url, *args, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        if url.endswith(".zip"):
+            if zip_files is None:
+                raise RuntimeError("no archive")
+            resp.content = _zip_bytes(zip_files)
+            return resp
+        if fail_csv or csv is None:
+            raise RuntimeError("not hosted")
+        resp.text = csv
+        return resp
+
+    return _get
+
+
+def _patch(**kwargs):
+    return patch(
+        "tidyfinance.download_open_source.requests.get",
+        side_effect=_fake_get(**kwargs),
+    )
+
+
+def test_apply_tcode_transforms():
+    """Each McCracken-Ng tcode (1-7) applies the expected causal transform."""
+    import numpy as np
+
+    x = np.array([1.0, 2.0, 4.0, 8.0])
+    np.testing.assert_array_equal(_apply_fred_md_tcode(x, 1), x)  # level
+    np.testing.assert_array_equal(
+        _apply_fred_md_tcode(x, 2), [np.nan, 1, 2, 4]
+    )  # diff
+    assert np.isnan(_apply_fred_md_tcode(x, 5)[0])  # dlog leads with NaN
+    with pytest.raises(ValueError, match="tcode"):
+        _apply_fred_md_tcode(x, 9)
+
+
+def test_latest_is_wide_raw_levels():
+    """vintage='latest' returns a wide [date, <series...>] frame of raw levels."""
+    with _patch():
+        result = _download_data_fred_md("fred_md_monthly")
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
+    assert "vintage" not in result.columns
+    assert result["date"].iloc[0] == pd.Timestamp("2020-01-01")
+    assert result["LEVELSER"].tolist() == [100, 101, 102]
+
+
+def test_transform_applies_per_series_tcode():
+    """transform=True applies each series' tcode; a tcode-1 series is unchanged."""
+    with _patch():
+        result = _download_data_fred_md("fred_md_monthly", transform=True)
+    assert result["LEVELSER"].tolist() == [100, 101, 102]  # tcode 1: unchanged
+    logdiff = result["LOGDIFFSER"]  # tcode 5: dlog, leads with NaN
+    assert pd.isna(logdiff.iloc[0])
+    assert logdiff.iloc[1] == pytest.approx(0.09531, abs=1e-4)
+
+
+def test_specific_vintage_individual_adds_column():
+    """A recent vintage (hosted individually) gets a 'vintage' column after 'date'."""
+    with _patch():
+        result = _download_data_fred_md("fred_md_monthly", vintage="2026-01")
+    assert list(result.columns[:2]) == ["date", "vintage"]
+    assert result["vintage"].unique().tolist() == ["2026-01"]
+
+
+def test_vintage_extracted_from_archive():
+    """An older vintage is extracted from the covering historical archive zip."""
+    files = {"2020-03.csv": _CSV}
+    with _patch(zip_files=files, fail_csv=True):
+        result = _download_data_fred_md("fred_md_monthly", vintage="2020-03")
+    assert result["vintage"].unique().tolist() == ["2020-03"]
+    assert "LEVELSER" in result.columns
+
+
+def test_all_stacks_vintages_wide():
+    """vintage='all' stacks every archived vintage into a wide real-time panel."""
+    files = {"2020-01.csv": _CSV, "2020-02.csv": _CSV}
+    with _patch(
+        zip_files=files, fail_csv=True
+    ):  # recent individual pulls all fail
+        result = _download_data_fred_md("fred_md_monthly", vintage="all")
+    assert list(result.columns[:2]) == ["date", "vintage"]
+    assert sorted(result["vintage"].unique()) == ["2020-01", "2020-02"]
+
+
+def test_invalid_vintage_raises():
+    with pytest.raises(ValueError, match="vintage must be"):
+        _download_data_fred_md("fred_md_monthly", vintage="banana")
+
+
+def test_invalid_dataset_raises():
+    with pytest.raises(ValueError, match="Unsupported FRED-MD/QD dataset"):
+        _download_data_fred_md("not_a_dataset")
+
+
+def test_supported_datasets_registered():
+    """FRED-MD and FRED-QD are discoverable via list_supported_datasets."""
+    datasets = list_supported_datasets()
+    types = set(datasets["type"])
+    assert {"fred_md_monthly", "fred_qd_quarterly"} <= types
+    assert {"FRED-MD", "FRED-QD"} <= set(datasets["domain"])
+
+
+def test_download_data_dispatch_fred_md():
+    """The public download_data routes the FRED-MD domain to the handler (wide output)."""
+    with _patch():
+        result = download_data("FRED-MD", "fred_md_monthly")
+    assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
+
+
+def test_download_data_dispatch_fred_qd():
+    """The public download_data routes the FRED-QD domain to the handler."""
+    with _patch():
+        result = download_data("FRED-QD", "fred_qd_quarterly")
+    assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_download_data_fred_md.py
+++ b/tests/test_download_data_fred_md.py
@@ -138,24 +138,23 @@ def test_invalid_database_raises():
 
 
 def test_supported_datasets_registered():
-    """FRED-MD and FRED-QD are discoverable via list_supported_datasets."""
+    """FRED-MD and FRED-QD are discoverable via list_supported_datasets (under the FRED domain)."""
     datasets = list_supported_datasets()
-    types = set(datasets["type"])
-    assert {"fred_md", "fred_qd"} <= types
-    assert {"FRED-MD", "FRED-QD"} <= set(datasets["domain"])
+    fred = datasets[datasets["domain"] == "FRED"]
+    assert {"FRED-MD", "FRED-QD"} <= set(fred["type"])
 
 
 def test_download_data_dispatch_fred_md():
-    """The public download_data routes the FRED-MD domain to the handler (wide output)."""
+    """download_data("FRED", "FRED-MD") routes to the FRED-MD handler (wide output)."""
     with _patch():
-        result = download_data("FRED-MD")
+        result = download_data("FRED", "FRED-MD")
     assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
 
 
 def test_download_data_dispatch_fred_qd():
-    """The public download_data routes the FRED-QD domain to the handler."""
+    """download_data("FRED", "FRED-QD") routes to the FRED-QD handler."""
     with _patch():
-        result = download_data("FRED-QD")
+        result = download_data("FRED", "FRED-QD")
     assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
 
 

--- a/tests/test_download_data_fred_md.py
+++ b/tests/test_download_data_fred_md.py
@@ -81,7 +81,7 @@ def test_apply_tcode_transforms():
 def test_latest_is_wide_raw_levels():
     """vintage='latest' returns a wide [date, <series...>] frame of raw levels."""
     with _patch():
-        result = _download_data_fred_md("fred_md_monthly")
+        result = _download_data_fred_md("FRED-MD")
     assert isinstance(result, pd.DataFrame)
     assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
     assert "vintage" not in result.columns
@@ -92,7 +92,7 @@ def test_latest_is_wide_raw_levels():
 def test_transform_applies_per_series_tcode():
     """transform=True applies each series' tcode; a tcode-1 series is unchanged."""
     with _patch():
-        result = _download_data_fred_md("fred_md_monthly", transform=True)
+        result = _download_data_fred_md("FRED-MD", transform=True)
     assert result["LEVELSER"].tolist() == [100, 101, 102]  # tcode 1: unchanged
     logdiff = result["LOGDIFFSER"]  # tcode 5: dlog, leads with NaN
     assert pd.isna(logdiff.iloc[0])
@@ -102,7 +102,7 @@ def test_transform_applies_per_series_tcode():
 def test_specific_vintage_individual_adds_column():
     """A recent vintage (hosted individually) gets a 'vintage' column after 'date'."""
     with _patch():
-        result = _download_data_fred_md("fred_md_monthly", vintage="2026-01")
+        result = _download_data_fred_md("FRED-MD", vintage="2026-01")
     assert list(result.columns[:2]) == ["date", "vintage"]
     assert result["vintage"].unique().tolist() == ["2026-01"]
 
@@ -111,7 +111,7 @@ def test_vintage_extracted_from_archive():
     """An older vintage is extracted from the covering historical archive zip."""
     files = {"2020-03.csv": _CSV}
     with _patch(zip_files=files, fail_csv=True):
-        result = _download_data_fred_md("fred_md_monthly", vintage="2020-03")
+        result = _download_data_fred_md("FRED-MD", vintage="2020-03")
     assert result["vintage"].unique().tolist() == ["2020-03"]
     assert "LEVELSER" in result.columns
 
@@ -122,40 +122,40 @@ def test_all_stacks_vintages_wide():
     with _patch(
         zip_files=files, fail_csv=True
     ):  # recent individual pulls all fail
-        result = _download_data_fred_md("fred_md_monthly", vintage="all")
+        result = _download_data_fred_md("FRED-MD", vintage="all")
     assert list(result.columns[:2]) == ["date", "vintage"]
     assert sorted(result["vintage"].unique()) == ["2020-01", "2020-02"]
 
 
 def test_invalid_vintage_raises():
     with pytest.raises(ValueError, match="vintage must be"):
-        _download_data_fred_md("fred_md_monthly", vintage="banana")
+        _download_data_fred_md("FRED-MD", vintage="banana")
 
 
-def test_invalid_dataset_raises():
-    with pytest.raises(ValueError, match="Unsupported FRED-MD/QD dataset"):
-        _download_data_fred_md("not_a_dataset")
+def test_invalid_database_raises():
+    with pytest.raises(ValueError, match="Unsupported database"):
+        _download_data_fred_md("not_a_database")
 
 
 def test_supported_datasets_registered():
     """FRED-MD and FRED-QD are discoverable via list_supported_datasets."""
     datasets = list_supported_datasets()
     types = set(datasets["type"])
-    assert {"fred_md_monthly", "fred_qd_quarterly"} <= types
+    assert {"fred_md", "fred_qd"} <= types
     assert {"FRED-MD", "FRED-QD"} <= set(datasets["domain"])
 
 
 def test_download_data_dispatch_fred_md():
     """The public download_data routes the FRED-MD domain to the handler (wide output)."""
     with _patch():
-        result = download_data("FRED-MD", "fred_md_monthly")
+        result = download_data("FRED-MD")
     assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
 
 
 def test_download_data_dispatch_fred_qd():
     """The public download_data routes the FRED-QD domain to the handler."""
     with _patch():
-        result = download_data("FRED-QD", "fred_qd_quarterly")
+        result = download_data("FRED-QD")
     assert list(result.columns) == ["date", "LEVELSER", "LOGDIFFSER"]
 
 

--- a/tidyfinance/download.py
+++ b/tidyfinance/download.py
@@ -190,13 +190,13 @@ def download_data(
     elif domain == "Index Constituents":
         processed_data = _download_data_constituents(dataset=dataset, **kwargs)
     elif domain == "FRED":
-        processed_data = _download_data_fred(
-            start_date=start_date, end_date=end_date, **kwargs
-        )
-    elif domain in ("FRED-MD", "FRED-QD"):
-        # FRED-MD/QD are single-product databases (frequency implied by the name) selected by
-        # 'vintage', not by a dataset or date slice — the domain alone identifies them.
-        processed_data = _download_data_fred_md(database=domain, **kwargs)
+        if dataset in ("FRED-MD", "FRED-QD"):
+            # Curated McCracken-Ng databases (selected by 'vintage', not date-sliced).
+            processed_data = _download_data_fred_md(database=dataset, **kwargs)
+        else:
+            processed_data = _download_data_fred(
+                start_date=start_date, end_date=end_date, **kwargs
+            )
     elif domain == "Stock Prices":
         processed_data = _download_data_stock_prices(
             start_date=start_date, end_date=end_date, **kwargs

--- a/tidyfinance/download.py
+++ b/tidyfinance/download.py
@@ -9,6 +9,7 @@ from .download_open_source import (
     _download_data_factors_ff,
     _download_data_factors_q,
     _download_data_fred,
+    _download_data_fred_md,
     _download_data_jkp,
     _download_data_macro_predictors,
     _download_data_osap,
@@ -192,6 +193,10 @@ def download_data(
         processed_data = _download_data_fred(
             start_date=start_date, end_date=end_date, **kwargs
         )
+    elif domain in ("FRED-MD", "FRED-QD"):
+        # FRED-MD/QD are single-product databases (frequency implied by the name) selected by
+        # 'vintage', not by a dataset or date slice — the domain alone identifies them.
+        processed_data = _download_data_fred_md(database=domain, **kwargs)
     elif domain == "Stock Prices":
         processed_data = _download_data_stock_prices(
             start_date=start_date, end_date=end_date, **kwargs

--- a/tidyfinance/download_open_source.py
+++ b/tidyfinance/download_open_source.py
@@ -1157,15 +1157,25 @@ def _download_data_fred_md(
         or ``'all'`` a ``'vintage'`` column (the ``YYYY-MM`` release label) is
         inserted after ``date``.
 
+    References
+    ----------
+    McCracken, M. W., and Ng, S. (2016). FRED-MD: A Monthly Database for
+    Macroeconomic Research. Journal of Business & Economic Statistics, 34(4),
+    574-589. https://doi.org/10.1080/07350015.2015.1086655
+
+    McCracken, M. W., and Ng, S. (2021). FRED-QD: A Quarterly Database for
+    Macroeconomic Research. Federal Reserve Bank of St. Louis Review, 103(1),
+    1-44. https://doi.org/10.20955/r.103.1-44
+
     Examples
     --------
     ```python
     from tidyfinance import download_data
-    download_data("FRED-MD")
-    download_data("FRED-MD", transform=True)
-    download_data("FRED-MD", vintage="2020-03")
-    download_data("FRED-MD", vintage="all")
-    download_data("FRED-QD")
+    download_data("FRED", "FRED-MD")
+    download_data("FRED", "FRED-MD", transform=True)
+    download_data("FRED", "FRED-MD", vintage="2020-03")
+    download_data("FRED", "FRED-MD", vintage="all")
+    download_data("FRED", "FRED-QD")
     ```
     """
     if database not in _FRED_MD_SPEC:

--- a/tidyfinance/download_open_source.py
+++ b/tidyfinance/download_open_source.py
@@ -968,6 +968,313 @@ def _download_data_fred(
     return fred_data
 
 
+_FRED_MD_BASE = "https://www.stlouisfed.org/-/media/project/frbstl/stlouisfed/research/fred-md"
+
+# Per-dataset spec: subdirectory, individual-vintage filename suffix ('md'/'qd'), and full-history
+# archive routing ranges (first, last, zip url). A specific historical vintage is extracted from
+# whichever archive covers it; more recent vintages are hosted individually. The clean Sitecore media
+# path resolves without the rotating '?sc_lang=&hash=' cache-buster query string.
+_FRED_MD_SPEC = {
+    "FRED-MD": {
+        "sub": "monthly",
+        "suffix": "md",
+        "archives": [
+            ("1999-01", "2014-12", f"{_FRED_MD_BASE}/historical_fred-md.zip"),
+            (
+                "2015-01",
+                "2024-12",
+                f"{_FRED_MD_BASE}/historical-vintages-of-fred-md-2015-01-to-2024-12.zip",
+            ),
+        ],
+    },
+    "FRED-QD": {
+        "sub": "quarterly",
+        "suffix": "qd",
+        "archives": [
+            (
+                "2018-05",
+                "2024-12",
+                f"{_FRED_MD_BASE}/historical-vintages-of-fred-qd-2018-05-to-2024-12.zip",
+            ),
+        ],
+    },
+}
+
+# Vintage labels embedded in archived filenames: 'YYYY-MM' or 'YYYYmMM'.
+_VINTAGE_DASH = re.compile(r"(\d{4})-(\d{2})")
+_VINTAGE_M = re.compile(r"(\d{4})m(\d{1,2})")
+
+
+def _apply_fred_md_tcode(x: np.ndarray, code: int) -> np.ndarray:
+    """Apply a McCracken-Ng stationarity transform (tcode 1-7) to a level series.
+
+    1 level, 2 diff, 3 diff^2, 4 log, 5 dlog, 6 dlog^2, 7 diff(x_t/x_{t-1} - 1).
+    All are causal (use only current and past values).
+    """
+    x = np.asarray(x, dtype=float)
+    if code == 1:
+        return x
+    if code == 2:
+        return np.append(np.nan, np.diff(x))
+    if code == 3:
+        return np.append([np.nan, np.nan], np.diff(x, n=2))
+    if code == 4:
+        return np.log(x)
+    if code == 5:
+        return np.append(np.nan, np.diff(np.log(x)))
+    if code == 6:
+        return np.append([np.nan, np.nan], np.diff(np.log(x), n=2))
+    if code == 7:
+        g = np.append(np.nan, x[1:] / x[:-1] - 1.0)
+        return np.append(np.nan, np.diff(g))
+    raise ValueError(f"Unknown FRED-MD tcode {code!r} (expected 1-7).")
+
+
+def _fetch_fred_md_text(url: str) -> str:
+    """GET a FRED-MD/QD CSV (Akamai-safe via curl_cffi impersonation); raise on failure."""
+    headers = {"User-Agent": _get_random_user_agent()}
+    response = requests.get(
+        url, headers=headers, impersonate="chrome110", timeout=60
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def _fetch_fred_md_bytes(url: str) -> bytes:
+    """GET a FRED-MD vintage archive (zip) as bytes."""
+    headers = {"User-Agent": _get_random_user_agent()}
+    response = requests.get(
+        url, headers=headers, impersonate="chrome110", timeout=180
+    )
+    response.raise_for_status()
+    return response.content
+
+
+def _looks_like_fred_md(text: str) -> bool:
+    """True if ``text`` is a FRED-MD/QD CSV (first cell ``sasdate``) — guards 200-OK HTML pages."""
+    first = text.lstrip("﻿").splitlines()[0] if text.strip() else ""
+    return first.split(",")[0].strip().lower() == "sasdate"
+
+
+def _vintage_label(name: str) -> str | None:
+    """Extract a ``YYYY-MM`` vintage label from an archived filename, or None."""
+    m = _VINTAGE_DASH.search(name) or _VINTAGE_M.search(name)
+    return f"{int(m.group(1)):04d}-{int(m.group(2)):02d}" if m else None
+
+
+def _fred_md_wide(text: str, transform: bool) -> pd.DataFrame:
+    """Parse one FRED-MD/QD vintage CSV into a wide frame ``[date, <series...>]``.
+
+    Row 1 is the header (``sasdate`` + series), row 2 the ``Transform:`` row of tcodes, and the body
+    the levels. With ``transform=True`` each series' McCracken-Ng stationarity transform (tcode) is
+    applied per vintage (causal, so point-in-time safe); ``transform=False`` keeps raw levels.
+    """
+    raw = pd.read_csv(io.StringIO(text))
+    date_col = raw.columns[0]
+    series_cols = list(raw.columns[1:])
+    tcodes = {c: int(float(raw.iloc[0][c])) for c in series_cols}
+
+    body = raw.iloc[1:]
+    ref = pd.to_datetime(body[date_col], format="%m/%d/%Y", errors="coerce")
+    keep = ref.notna()
+    levels = body.loc[keep, series_cols].apply(pd.to_numeric, errors="coerce")
+    levels.index = pd.DatetimeIndex(ref[keep], name="date")
+    if transform:
+        levels = pd.DataFrame(
+            {
+                c: _apply_fred_md_tcode(levels[c].to_numpy(), tcodes[c])
+                for c in series_cols
+            },
+            index=levels.index,
+        )
+    return levels.reset_index()
+
+
+def _read_archive(
+    url: str, transform: bool, want: str | None = None
+) -> dict[str, pd.DataFrame]:
+    """Download a vintage archive (zip) and parse its CSVs → ``{vintage_label: wide_frame}``.
+
+    ``want`` returns just that one vintage (stops early); otherwise every vintage in the zip.
+    """
+    out: dict[str, pd.DataFrame] = {}
+    with zipfile.ZipFile(io.BytesIO(_fetch_fred_md_bytes(url))) as zf:
+        for name in zf.namelist():
+            if not name.lower().endswith(".csv"):
+                continue
+            label = _vintage_label(name.rsplit("/", 1)[-1])
+            if (
+                label is None
+                or label in out
+                or (want is not None and label != want)
+            ):
+                continue
+            text = zf.read(name).decode("latin-1")
+            if _looks_like_fred_md(text):
+                out[label] = _fred_md_wide(text, transform)
+                if want is not None:
+                    break
+    return out
+
+
+def _download_data_fred_md(
+    database: str = "FRED-MD",
+    transform: bool = False,
+    vintage: str = "latest",
+) -> pd.DataFrame:
+    """
+    Download and process a FRED-MD / FRED-QD database (McCracken-Ng).
+
+    Fetches a vintage of the FRED-MD (monthly) or FRED-QD (quarterly)
+    macroeconomic database - a curated, balanced panel of macro series - as a
+    wide table (one column per series, matching the other factor/predictor
+    datasets). Each series has a McCracken-Ng stationarity transform code
+    (tcode); ``transform=True`` applies it per series. FRED-MD/QD publish a new
+    vintage every month, so a specific release can be requested by its
+    ``YYYY-MM`` label - or the entire real-time panel with ``vintage='all'`` -
+    for point-in-time analysis.
+
+    Parameters
+    ----------
+    database : str
+        Which database to download: ``'FRED-MD'`` (monthly) or ``'FRED-QD'``
+        (quarterly). The frequency is implied by the database.
+    transform : bool, default False
+        If ``True``, apply each series' McCracken-Ng stationarity transform
+        (tcode 1-7). If ``False``, return raw levels.
+    vintage : str, default 'latest'
+        Which release(s) to download: ``'latest'`` (the current vintage), a
+        ``'YYYY-MM'`` label for one historical release (e.g. ``'2020-03'``;
+        recent ones are hosted individually, older ones are extracted from the
+        St. Louis Fed vintage archives), or ``'all'`` for every archived
+        vintage stacked (the full real-time panel; FRED-MD reaches back to
+        1999-08, FRED-QD to 2018-05).
+
+    Returns
+    -------
+    pd.DataFrame
+        A wide data frame ``['date', <series...>]``. For a specific ``vintage``
+        or ``'all'`` a ``'vintage'`` column (the ``YYYY-MM`` release label) is
+        inserted after ``date``.
+
+    Examples
+    --------
+    ```python
+    from tidyfinance import download_data
+    download_data("FRED-MD")
+    download_data("FRED-MD", transform=True)
+    download_data("FRED-MD", vintage="2020-03")
+    download_data("FRED-MD", vintage="all")
+    download_data("FRED-QD")
+    ```
+    """
+    if database not in _FRED_MD_SPEC:
+        raise ValueError(
+            f"Unsupported database: {database!r}. Use 'FRED-MD' or 'FRED-QD'."
+        )
+    sub = _FRED_MD_SPEC[database]["sub"]
+
+    if vintage == "latest":
+        text = _fetch_fred_md_text(f"{_FRED_MD_BASE}/{sub}/current.csv")
+        if not _looks_like_fred_md(text):
+            raise ValueError(
+                "The FRED-MD/QD 'current' file was not a valid CSV; try again later."
+            )
+        return _fred_md_wide(text, transform)
+
+    if vintage == "all":
+        return _download_fred_md_all(database, transform)
+
+    if not re.fullmatch(r"\d{4}-\d{2}", vintage):
+        raise ValueError(
+            f"vintage must be 'latest', 'all', or a 'YYYY-MM' label; got {vintage!r}."
+        )
+
+    frame = _download_fred_md_vintage(database, vintage, transform)
+    frame.insert(1, "vintage", vintage)
+    return frame
+
+
+def _fred_md_individual_names(label: str, suffix: str) -> tuple[str, ...]:
+    """Candidate individually-hosted filenames for a vintage: e.g. '2025-04-md.csv',
+    'fred-md_2025m04.csv', '2025-04.csv'."""
+    year, month = label.split("-")
+    return (
+        f"{label}-{suffix}.csv",
+        f"fred-{suffix}_{year}m{month}.csv",
+        f"{label}.csv",
+    )
+
+
+def _download_fred_md_vintage(
+    database: str, vintage: str, transform: bool
+) -> pd.DataFrame:
+    """One historical release: from the covering archive if any, else the individually-hosted file."""
+    spec = _FRED_MD_SPEC[database]
+    for lo, hi, url in spec["archives"]:
+        if lo <= vintage <= hi:
+            found = _read_archive(url, transform, want=vintage)
+            if vintage in found:
+                return found[vintage]
+            raise ValueError(
+                f"vintage {vintage!r} not found in its FRED-MD/QD archive."
+            )
+
+    sub = spec["sub"]
+    for name in _fred_md_individual_names(vintage, spec["suffix"]):
+        try:
+            text = _fetch_fred_md_text(f"{_FRED_MD_BASE}/{sub}/{name}")
+        except Exception:
+            continue
+        if _looks_like_fred_md(
+            text
+        ):  # reject 200-OK HTML placeholders for unpublished months
+            return _fred_md_wide(text, transform)
+    raise ValueError(
+        f"Could not fetch FRED-MD/QD vintage {vintage!r} (not in an archive and not "
+        "individually hosted - it may be unpublished)."
+    )
+
+
+def _download_fred_md_all(database: str, transform: bool) -> pd.DataFrame:
+    """Every archived vintage + the individually-hosted recent ones → wide real-time panel."""
+    spec = _FRED_MD_SPEC[database]
+    frames: dict[str, pd.DataFrame] = {}
+    last_archived = None
+    for _lo, hi, url in spec["archives"]:
+        frames.update(_read_archive(url, transform))
+        last_archived = hi if last_archived is None else max(last_archived, hi)
+
+    sub, suffix = spec["sub"], spec["suffix"]
+    recent = pd.period_range(
+        last_archived or "2015-01",
+        pd.Timestamp.today().to_period("M"),
+        freq="M",
+    )
+    for period in recent:
+        label = f"{period.year:04d}-{period.month:02d}"
+        if label in frames:
+            continue
+        for name in _fred_md_individual_names(label, suffix):
+            try:
+                text = _fetch_fred_md_text(f"{_FRED_MD_BASE}/{sub}/{name}")
+            except Exception:
+                continue
+            if _looks_like_fred_md(text):
+                frames[label] = _fred_md_wide(text, transform)
+                break
+
+    if not frames:
+        raise ValueError("No FRED-MD/QD vintages could be downloaded.")
+    parts = []
+    for label, frame in frames.items():
+        frame = frame.copy()
+        frame.insert(1, "vintage", label)
+        parts.append(frame)
+    out = pd.concat(parts, ignore_index=True)
+    return out.sort_values(["vintage", "date"]).reset_index(drop=True)
+
+
 def _download_data_stock_prices(
     symbols: str | list,
     start_date: str = None,

--- a/tidyfinance/supported_datasets.py
+++ b/tidyfinance/supported_datasets.py
@@ -2061,14 +2061,14 @@ _OTHER_DATASETS = [
     },
     {"type": "fred", "dataset_name": "various", "domain": "FRED"},
     {
-        "type": "fred_md",
+        "type": "FRED-MD",
         "dataset_name": "FRED-MD (McCracken-Ng, monthly)",
-        "domain": "FRED-MD",
+        "domain": "FRED",
     },
     {
-        "type": "fred_qd",
+        "type": "FRED-QD",
         "dataset_name": "FRED-QD (McCracken-Ng, quarterly)",
-        "domain": "FRED-QD",
+        "domain": "FRED",
     },
     {
         "type": "osap",
@@ -2196,8 +2196,6 @@ _SUPPORTED_DOMAINS: tuple[str, ...] = (
     "Pseudo Data",
     "Index Constituents",
     "FRED",
-    "FRED-MD",
-    "FRED-QD",
     "Stock Prices",
     "Open Source Asset Pricing",
     "Global Factor Data",

--- a/tidyfinance/supported_datasets.py
+++ b/tidyfinance/supported_datasets.py
@@ -2061,6 +2061,16 @@ _OTHER_DATASETS = [
     },
     {"type": "fred", "dataset_name": "various", "domain": "FRED"},
     {
+        "type": "fred_md",
+        "dataset_name": "FRED-MD (McCracken-Ng, monthly)",
+        "domain": "FRED-MD",
+    },
+    {
+        "type": "fred_qd",
+        "dataset_name": "FRED-QD (McCracken-Ng, quarterly)",
+        "domain": "FRED-QD",
+    },
+    {
         "type": "osap",
         "dataset_name": "Open Source Asset Pricing",
         "domain": "Open Source Asset Pricing",
@@ -2186,6 +2196,8 @@ _SUPPORTED_DOMAINS: tuple[str, ...] = (
     "Pseudo Data",
     "Index Constituents",
     "FRED",
+    "FRED-MD",
+    "FRED-QD",
     "Stock Prices",
     "Open Source Asset Pricing",
     "Global Factor Data",


### PR DESCRIPTION
Implements #62. Updated per review: routed via the existing `FRED` domain
(`download_data("FRED", "FRED-MD")`), the McCracken-Ng papers are cited in the docstring, and a
CHANGELOG entry is added. The R version is left to the maintainers, per #62.

## What this adds

`download_data` gains the **FRED-MD** (monthly) and **FRED-QD** (quarterly) McCracken-Ng
macroeconomic databases — curated, balanced panels of ~127 / ~245 series that the existing
single-series `FRED` path can't read (they ship in a two-header-row bulk format with a per-series
stationarity transform code).

```python
download_data("FRED", "FRED-MD")                    # current vintage (wide)
download_data("FRED", "FRED-MD", transform=True)    # apply McCracken-Ng tcodes
download_data("FRED", "FRED-MD", vintage="2020-03") # a specific historical release
download_data("FRED", "FRED-MD", vintage="all")     # the full real-time panel
download_data("FRED", "FRED-QD")
```

- Selected via the existing **`FRED` domain** with `dataset="FRED-MD"` / `"FRED-QD"`. **Single-series
  FRED is unaffected** — the dispatch only wraps the original call in an `else` branch.
- **Wide output** `["date", <series…>]` — one column per series, matching `factors_ff` /
  `macro_predictors` / `osap`. Honors the polars/pandas backend.
- **`transform`** applies each series' McCracken-Ng tcode (1–7) per vintage (causal ⇒ PIT-safe);
  `transform=False` keeps raw levels.
- **`vintage`** = `"latest"` (default) | `"YYYY-MM"` | `"all"`. Recent releases are hosted
  individually; older ones are extracted from the St. Louis Fed vintage archives via an encoded
  date→archive map. Non-`latest` inserts a `"vintage"` column — this is the point-in-time payoff
  (2020 macro data was revised heavily; see #62 for a concrete revision table).
- Curated panels selected by `vintage`, so no `start_date` / `end_date`.

## Changes

- `download_open_source.py`: `_download_data_fred_md` + helpers (`_fred_md_wide`, `_read_archive`,
  tcode transform, vintage routing) + a `References` section citing McCracken & Ng (2016, 2021).
- `download.py`: the `FRED` domain branches on `dataset` — `"FRED-MD"` / `"FRED-QD"` go to the new
  handler, everything else stays single-series `_download_data_fred`.
- `supported_datasets.py`: `FRED-MD` / `FRED-QD` datasets under the `FRED` domain.
- `CHANGELOG.md`: an Unreleased entry.

## Verified (live)

| call | result |
|------|--------|
| `download_data("FRED", "FRED-MD")` | wide `(801, 127)` — date + 126 series |
| `download_data("FRED", "FRED-MD", vintage="2020-03")` | extracted from the 2015–2024 archive, ~1 s |
| `download_data("FRED", "FRED-MD", vintage="all")` | **322 vintages, 1999-08 … present**, `(208k, 146)`, ~245 MB, ~26 s |
| `download_data("FRED", "FRED-QD")` | wide `(267, 246)` — date + 245 series |
| `download_data("FRED", "FRED-QD", vintage="all")` | **97 vintages, 2018-05 … present**, `(24.5k, 261)`, ~51 MB, ~19 s |
| `download_data("FRED", series=[...])` | unchanged — single-series `["date", "series", "value"]` |

The wide layout keeps `all` compact. Recent vintages are hosted individually (`YYYY-MM-md.csv` /
`-qd.csv`); older ones come from the St. Louis Fed historical archive zips via an encoded
date→archive map.

## One open design question

The `vintage` column is a **new dimension** — no existing tidyfinance dataset carries a
release/vintage axis. I've made it a per-dataset extra column present only when `vintage != "latest"`.
Happy to change the shape/name if you'd prefer something else. (Availability lag is deliberately left
as a downstream concern.)

## Included

- [x] **Tests** — `tests/test_download_data_fred_md.py`, mocked/offline in the existing
  `test_download_data_fred.py` style (tcodes, wide latest, transform, specific vintage from an
  individual file *and* an archive, `all` stacking, errors, `supported_datasets` registration, and
  `download_data` dispatch for both databases). 11 tests, ~0.8 s.
- [x] **CHANGELOG** entry (Unreleased).
- [x] **Paper citations** (McCracken & Ng 2016 / 2021) in the docstring.

Left to the maintainers, per #62: the `r-tidyfinance` version.

*Clean-room from the public McCracken-Ng file format; no third-party code.*
