### PR TITLE
Return WRDS date columns as polars Date under the polars backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 - **Polars backend returns WRDS date columns as `Date` (#66):** With
   `set_backend("polars")`, the calendar-date columns of the WRDS
-  downloads (e.g. `trd_exctn_dt` from `trace_enhanced`, `datadate` and
-  `rdq` from Compustat, `linkdt`/`linkenddt` from CCM links, and the
-  FISD date columns) are now cast to `polars.Date` instead of
-  surfacing as `polars.Datetime`, matching the R package and the
-  existing normalization of the `date` column. This fixes
-  `SchemaError`s when joining or vertically stacking TRACE output
-  against `Date`-typed frames. True time-of-day columns (e.g.
-  `trd_exctn_tm`) are unaffected.
+  downloads (`trd_exctn_dt` from `trace_enhanced`, `datadate` from
+  Compustat, `linkdt`/`linkenddt` from CCM links, `calculation_date`
+  from monthly CRSP, and the FISD date columns) are now cast to
+  `polars.Date` instead of surfacing as `polars.Datetime`, matching
+  the R package and the existing normalization of the `date` column.
+  This fixes `SchemaError`s when joining or vertically stacking TRACE
+  output against `Date`-typed frames. True time-of-day columns (e.g.
+  `trd_exctn_tm`) and timezone-aware datetimes are unaffected.
 - **Added FRED-MD and FRED-QD macroeconomic databases:**
   `download_data("FRED", "FRED-MD")` and `download_data("FRED", "FRED-QD")`
   download the McCracken and Ng (2016, 2021) curated monthly / quarterly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Polars backend returns WRDS date columns as `Date` (#66):** With
+  `set_backend("polars")`, the calendar-date columns of the WRDS
+  downloads (e.g. `trd_exctn_dt` from `trace_enhanced`, `datadate` and
+  `rdq` from Compustat, `linkdt`/`linkenddt` from CCM links, and the
+  FISD date columns) are now cast to `polars.Date` instead of
+  surfacing as `polars.Datetime`, matching the R package and the
+  existing normalization of the `date` column. This fixes
+  `SchemaError`s when joining or vertically stacking TRACE output
+  against `Date`-typed frames. True time-of-day columns (e.g.
+  `trd_exctn_tm`) are unaffected.
 - **Added FRED-MD and FRED-QD macroeconomic databases:**
   `download_data("FRED", "FRED-MD")` and `download_data("FRED", "FRED-QD")`
   download the McCracken and Ng (2016, 2021) curated monthly / quarterly

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,5 +1,6 @@
 """Tests for the global data frame backend (pandas/polars)."""
 
+import datetime
 import os
 import sys
 
@@ -127,6 +128,24 @@ def test_convert_output_keeps_unknown_datetime_columns():
     out = _convert_output(df)
     assert out.schema["timestamp"] == pl.Datetime
     assert out.schema["trd_exctn_dt"] == pl.Date
+
+
+def test_convert_output_keeps_timezone_aware_datetime_columns():
+    """Timezone-aware datetimes are never cast: taking the UTC calendar
+    date could differ from the wall-clock date."""
+    tf.set_backend("polars")
+    # fixed-offset timezone so the test needs no zoneinfo database
+    tz = datetime.timezone(datetime.timedelta(hours=-5))
+    df = pd.DataFrame(
+        {
+            "trd_exctn_dt": pd.to_datetime(["2020-01-01 23:30:00"]).tz_localize(
+                tz
+            ),
+        }
+    )
+    out = _convert_output(df)
+    assert out.schema["trd_exctn_dt"] == pl.Datetime
+    assert out.schema["trd_exctn_dt"].time_zone is not None
 
 
 def test_convert_output_keeps_non_datetime_date_named_columns():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -88,6 +88,56 @@ def test_convert_output_casts_date_column_to_polars_date():
     ]
 
 
+def test_convert_output_casts_wrds_date_columns_to_polars_date():
+    """Date-typed WRDS columns (TRACE, Compustat, CCM links, FISD) must
+    come out as polars Date, not Datetime (issue #66)."""
+    tf.set_backend("polars")
+    days = pd.to_datetime(["2019-01-02", "2019-01-03"])
+    df = pd.DataFrame(
+        {
+            "trd_exctn_dt": days,
+            "trd_rpt_dt": days,
+            "stlmnt_dt": days,
+            "datadate": days,
+            "rdq": days,
+            "linkdt": days,
+            "linkenddt": days,
+            "maturity": days,
+            "offering_date": days,
+            "dated_date": days,
+            "last_interest_date": days,
+            "calculation_date": days,
+        }
+    )
+    out = _convert_output(df)
+    for column in df.columns:
+        assert out.schema[column] == pl.Date, column
+
+
+def test_convert_output_keeps_unknown_datetime_columns():
+    """Only known calendar-date columns are cast; other datetime
+    columns (e.g. user-supplied timestamps) keep their type."""
+    tf.set_backend("polars")
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2020-01-31 09:30:00"]),
+            "trd_exctn_dt": pd.to_datetime(["2020-01-31"]),
+        }
+    )
+    out = _convert_output(df)
+    assert out.schema["timestamp"] == pl.Datetime
+    assert out.schema["trd_exctn_dt"] == pl.Date
+
+
+def test_convert_output_keeps_non_datetime_date_named_columns():
+    """A known date-column name that is not datetime-typed (e.g. a
+    string) passes through unchanged."""
+    tf.set_backend("polars")
+    df = pd.DataFrame({"datadate": ["2020-01-31"], "v": [1.0]})
+    out = _convert_output(df)
+    assert out.schema["datadate"] == pl.String
+
+
 def test_convert_output_drops_default_rangeindex():
     tf.set_backend("polars")
     out = _convert_output(pd.DataFrame({"a": [1, 2]}))

--- a/tests/test_download_data_wrds_fisd.py
+++ b/tests/test_download_data_wrds_fisd.py
@@ -5,13 +5,23 @@ import sys
 from unittest.mock import patch
 
 import pandas as pd
+import polars as pl
 import pytest
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 )
 
+import tidyfinance as tf  # noqa: E402
 from tidyfinance.download_wrds import _download_data_wrds_fisd  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_backend():
+    """Ensure the global backend never leaks between tests."""
+    tf.set_backend("pandas")
+    yield
+    tf.set_backend("pandas")
 
 
 def test_downloads_filtered_fisd_data_for_usa_issuers():
@@ -90,6 +100,61 @@ def test_downloads_filtered_fisd_data_for_usa_issuers():
     assert len(result) == 1
     assert result["complete_cusip"].iloc[0] == "111111111"
     assert result["sic_code"].iloc[0] == "1234"
+
+
+def test_download_data_fisd_polars_returns_date_columns():
+    """With the polars backend, the FISD calendar-date columns must
+    come out as polars Date, not Datetime (issue #66). The mocked
+    frames carry datetime64 columns, mirroring what the real path
+    produces via read_sql_query(..., parse_dates=...)."""
+    issue_filtered = pd.DataFrame(
+        {
+            "complete_cusip": ["111111111"],
+            "maturity": pd.to_datetime(["2030-01-01"]),
+            "offering_amt": [100],
+            "offering_date": pd.to_datetime(["2020-01-01"]),
+            "dated_date": pd.to_datetime(["2020-01-02"]),
+            "interest_frequency": ["2"],
+            "coupon": [5],
+            "last_interest_date": pd.to_datetime(["2029-12-31"]),
+            "issue_id": [1],
+            "issuer_id": [1],
+        }
+    )
+    issuer = pd.DataFrame(
+        {
+            "issuer_id": [1],
+            "sic_code": ["1234"],
+            "country_domicile": ["USA"],
+        }
+    )
+
+    def fake_read_sql_query(sql=None, con=None, *a, **kw):
+        if "fisd_mergedissuer" in str(sql):
+            return issuer
+        return issue_filtered
+
+    tf.set_backend("polars")
+    with (
+        patch(
+            "tidyfinance.download_wrds.get_wrds_connection", return_value="con"
+        ),
+        patch("tidyfinance.download_wrds.disconnect_connection"),
+        patch(
+            "tidyfinance.download_wrds.pd.read_sql_query",
+            side_effect=fake_read_sql_query,
+        ),
+    ):
+        out = tf.download_data(domain="WRDS", dataset="fisd")
+
+    assert isinstance(out, pl.DataFrame)
+    for column in [
+        "maturity",
+        "offering_date",
+        "dated_date",
+        "last_interest_date",
+    ]:
+        assert out.schema[column] == pl.Date, column
 
 
 def test_returns_requested_additional_columns():

--- a/tests/test_download_data_wrds_trace_enhanced.py
+++ b/tests/test_download_data_wrds_trace_enhanced.py
@@ -5,14 +5,24 @@ import sys
 from unittest.mock import patch
 
 import pandas as pd
+import polars as pl
 import pytest
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 )
 
+import tidyfinance as tf  # noqa: E402
 from tidyfinance.download_wrds import _download_data_wrds_trace_enhanced  # noqa: E402
 from tidyfinance.download_wrds import process_trace_data  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_backend():
+    """Ensure the global backend never leaks between tests."""
+    tf.set_backend("pandas")
+    yield
+    tf.set_backend("pandas")
 
 
 def test_download_data_wrds_trace_enhanced_validates_cusips():
@@ -121,6 +131,62 @@ def test_download_data_wrds_trace_enhanced_cleans_trace_data():
     assert expected_vols.issubset(actual_vols) or actual_vols.issubset(
         expected_vols
     )
+
+
+def test_download_data_trace_enhanced_polars_returns_date_columns():
+    """With the polars backend, 'trd_exctn_dt' (the only date column in
+    the cleaned TRACE output) must come out as polars Date so it
+    joins/stacks against Date-typed frames, while the time column stays
+    untouched (issue #66)."""
+    d = pd.Timestamp("2019-01-02")
+    trace = pd.DataFrame(
+        [
+            {
+                "cusip_id": "00101JAH9",
+                "bond_sym_id": "AA.GH",
+                "msg_seq_nb": 10,
+                "orig_msg_seq_nb": None,
+                "entrd_vol_qt": 100,
+                "rptd_pr": 99,
+                "yld_pt": 4,
+                "rpt_side_cd": "B",
+                "cntra_mp_id": "C",
+                "trd_exctn_dt": d,
+                "trd_exctn_tm": "10:00:00",
+                "trd_rpt_dt": d,
+                "trd_rpt_tm": "10:01:00",
+                "trc_st": "T",
+                "asof_cd": "",
+                "wis_fl": "N",
+                "days_to_sttl_ct": 1,
+                "lckd_in_ind": "",
+                "sale_cndtn_cd": "",
+                "stlmnt_dt": d + pd.Timedelta(days=1),
+                "spcl_trd_fl": "",
+            }
+        ]
+    )
+
+    tf.set_backend("polars")
+    with (
+        patch(
+            "tidyfinance.download_wrds.get_wrds_connection", return_value="con"
+        ),
+        patch("tidyfinance.download_wrds.disconnect_connection"),
+        patch("tidyfinance.download_wrds.pd.read_sql", return_value=trace),
+    ):
+        out = tf.download_data(
+            domain="WRDS",
+            dataset="trace_enhanced",
+            cusips=["00101JAH9"],
+            start_date="2019-01-01",
+            end_date="2021-12-31",
+        )
+
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 1
+    assert out.schema["trd_exctn_dt"] == pl.Date
+    assert out.schema["trd_exctn_tm"] == pl.String
 
 
 def test_process_trace_data_uses_2012_02_06_regime_cutoff():

--- a/tidyfinance/backend.py
+++ b/tidyfinance/backend.py
@@ -24,6 +24,35 @@ _VALID_BACKENDS = ("pandas", "polars")
 
 _BACKEND = "pandas"
 
+# Calendar-date columns returned by the download functions. Internally
+# pandas stores them as datetime64 (there is no plain date dtype), so
+# they would surface as 'polars.Datetime' under the polars backend.
+# '_convert_output' casts them to 'polars.Date' so they match the R
+# package and can be joined or stacked against 'Date'-typed frames.
+_DATE_COLUMNS = frozenset(
+    {
+        # all download functions
+        "date",
+        # WRDS CRSP
+        "calculation_date",
+        # WRDS Compustat
+        "datadate",
+        "rdq",
+        # WRDS CCM links
+        "linkdt",
+        "linkenddt",
+        # WRDS FISD
+        "maturity",
+        "offering_date",
+        "dated_date",
+        "last_interest_date",
+        # WRDS Enhanced TRACE
+        "trd_exctn_dt",
+        "trd_rpt_dt",
+        "stlmnt_dt",
+    }
+)
+
 
 def set_backend(backend: str) -> None:
     """Set the global data frame backend for the tidyfinance API.
@@ -101,9 +130,12 @@ def _convert_output(obj):
     unchanged. With the '"polars"' backend, a pandas data frame is
     converted via :func:'polars.from_pandas'. A non-default index (a
     named index or a non-'RangeIndex', such as a date index) is
-    preserved as a column, since polars has no concept of an index. A
-    'date' column is cast to 'polars.Date' so it prints as
-    'YYYY-MM-DD' instead of a datetime with a trailing zero time.
+    preserved as a column, since polars has no concept of an index.
+    Known calendar-date columns ('_DATE_COLUMNS', e.g. 'date',
+    'datadate', 'trd_exctn_dt') are cast from 'polars.Datetime' to
+    'polars.Date' so they print as 'YYYY-MM-DD' and join or stack
+    cleanly against 'Date'-typed frames. Other datetime columns pass
+    through unchanged.
     """
     if get_backend() != "polars":
         return obj
@@ -119,8 +151,13 @@ def _convert_output(obj):
         isinstance(obj.index, pd.RangeIndex) and obj.index.name is None
     )
     out = pl.from_pandas(obj, include_index=include_index)
-    if "date" in out.columns and out.schema["date"] == pl.Datetime:
-        out = out.with_columns(pl.col("date").cast(pl.Date))
+    date_casts = [
+        pl.col(name).cast(pl.Date)
+        for name in out.columns
+        if name in _DATE_COLUMNS and out.schema[name] == pl.Datetime
+    ]
+    if date_casts:
+        out = out.with_columns(date_casts)
     return out
 
 

--- a/tidyfinance/backend.py
+++ b/tidyfinance/backend.py
@@ -24,11 +24,14 @@ _VALID_BACKENDS = ("pandas", "polars")
 
 _BACKEND = "pandas"
 
-# Calendar-date columns returned by the download functions. Internally
+# Calendar-date columns handled by the download functions. Internally
 # pandas stores them as datetime64 (there is no plain date dtype), so
 # they would surface as 'polars.Datetime' under the polars backend.
 # '_convert_output' casts them to 'polars.Date' so they match the R
 # package and can be joined or stacked against 'Date'-typed frames.
+# Some names ('rdq', 'trd_rpt_dt', 'stlmnt_dt') are dropped before the
+# downloads return and are listed defensively for raw frames that
+# users pass through the analytics functions.
 _DATE_COLUMNS = frozenset(
     {
         # all download functions
@@ -78,6 +81,13 @@ def set_backend(backend: str) -> None:
     round-trip through pandas on every step, which adds a measurable
     cost on large panels. The pandas backend is a pass-through with
     zero conversion overhead.
+
+    On conversion to polars, known calendar-date columns (e.g. 'date',
+    'datadate', 'trd_exctn_dt') are cast from 'polars.Datetime' to
+    'polars.Date', since pandas has no plain date dtype and would
+    otherwise surface them as datetimes. Any time-of-day component in
+    a column with one of these names is therefore dropped on output.
+    Timezone-aware datetime columns are never cast.
     """
     global _BACKEND
     if backend not in _VALID_BACKENDS:
@@ -154,7 +164,11 @@ def _convert_output(obj):
     date_casts = [
         pl.col(name).cast(pl.Date)
         for name in out.columns
-        if name in _DATE_COLUMNS and out.schema[name] == pl.Datetime
+        if name in _DATE_COLUMNS
+        and out.schema[name] == pl.Datetime
+        # never cast timezone-aware datetimes: casting would take the
+        # UTC calendar date, which can differ from the wall-clock date
+        and out.schema[name].time_zone is None
     ]
     if date_casts:
         out = out.with_columns(date_casts)


### PR DESCRIPTION
Closes #66.

## Problem

With `set_backend("polars")`, the WRDS Enhanced TRACE download returned `trd_exctn_dt` as `Datetime` instead of `Date`, so joining or vertically stacking TRACE output against `Date`-typed frames raised a polars `SchemaError` (this broke the Tidy Finance book's `trace-and-fisd` chapter). The same gap existed for the other calendar-date columns of the WRDS paths.

## Why the fix lives in `backend.py`

The package is pandas-internal, and pandas has no plain date dtype — calendar dates are stored as `datetime64` and only become distinguishable from timestamps at the pandas→polars conversion boundary (`backend._convert_output`). That is also where the earlier `stock_prices`/`famafrench` normalization landed: `_convert_output` already cast a column literally named `date` to `polars.Date`. This PR extends that mechanism instead of adding per-download casts.

## Changes

- **`tidyfinance/backend.py`:** new `_DATE_COLUMNS` set naming the calendar-date columns handled by the download functions — TRACE (`trd_exctn_dt`, `trd_rpt_dt`, `stlmnt_dt`), Compustat (`datadate`, `rdq`), CCM links (`linkdt`, `linkenddt`), FISD (`maturity`, `offering_date`, `dated_date`, `last_interest_date`), and monthly CRSP (`calculation_date`), alongside the existing `date`. `_convert_output` casts these to `polars.Date` only when they arrive as timezone-naive `Datetime`; true time-of-day columns (`trd_exctn_tm`, `trd_rpt_tm`), unknown datetime columns, and timezone-aware columns pass through unchanged. The coercion is documented in the user-facing `set_backend` docstring.
- **Audit of the remaining WRDS paths:** all date-bearing outputs are covered. Columns fetched without `parse_dates` (e.g. extra FISD/Compustat columns) arrive as object-dtype `datetime.date` and already convert to `polars.Date` via pyarrow. `dlstdt`/`first_crsp_date` are dropped or renamed before return; `rdq`/`trd_rpt_dt`/`stlmnt_dt` never surface in download output and are listed defensively for raw frames passed through the wrapped analytics functions.
- **Tests:** unit tests in `tests/test_backend.py` (all listed names cast; unknown datetime columns, tz-aware datetimes, and non-datetime columns untouched) plus mocked public-path schema tests for `download_data(domain="WRDS", dataset="trace_enhanced")` and `dataset="fisd"`, mirroring how the `stock_prices`/`famafrench` normalization is covered.
- **CHANGELOG** entry under Unreleased.

## Verification

- `uv run pytest`: 651 passed; the single failure (`test_download_data_column_ordering`) is a pre-existing network-dependent test unrelated to this change.
- `uv run ruff check .` / `ruff format --check`: no new findings (the 3 existing lint errors pre-date this branch).
- The change went through two rounds of adversarial review before opening this PR; all findings (a timezone-aware-datetime guard, CHANGELOG accuracy, and a non-self-referential public-path schema test) were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuBz47uxzcntrJ4b5YJ61h

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuBz47uxzcntrJ4b5YJ61h)_