### PR TITLE
Patch to _download_data_wrds_compustat

### DIFF
--- a/tidyfinance/download_wrds.py
+++ b/tidyfinance/download_wrds.py
@@ -1189,7 +1189,7 @@ def _download_data_wrds_compustat(
             compustat = compustat[compustat["curcdq"] == "USD"]
 
         processed_data = compustat.get(
-            ["gvkey", "date", "datadate", "atq", "ceqq"] + extra_quarterly
+            ["date"] + _base_quarterly_cols + extra_quarterly
         )
 
     return processed_data

--- a/tidyfinance/download_wrds.py
+++ b/tidyfinance/download_wrds.py
@@ -1188,11 +1188,7 @@ def _download_data_wrds_compustat(
         if only_usd:
             compustat = compustat[compustat["curcdq"] == "USD"]
 
-        processed_data = compustat.get(
-            ["date"] + _base_quarterly_cols + extra_quarterly
-        )
-
-    return processed_data
+    return compustat
 
 
 def _download_data_wrds_fisd(additional_columns: list = None) -> pd.DataFrame:


### PR DESCRIPTION
Fixed inability of _download_data_wrds_compustat to download rdq, fyearq, and fqtr

This line 

processed_data = compustat.get(
            ["gvkey", "date", "datadate", "atq", "ceqq"] + extra_quarterly
 )

prevented the download of those columns because they are in _base_quarterly_cols, which means they are excluded from extra_quarterly