### PR TITLE
Return requested base quarterly columns from Compustat download

### DIFF
--- a/tests/test_download_data_wrds_compustat.py
+++ b/tests/test_download_data_wrds_compustat.py
@@ -192,6 +192,52 @@ def test_quarterly_data_are_cleaned_and_filtered():
     ]
 
 
+def test_quarterly_base_columns_can_be_requested():
+    """Test base quarterly columns are returned when requested."""
+    fundq = pd.DataFrame(
+        {
+            "gvkey": ["001", "002"],
+            "datadate": pd.to_datetime(["2020-03-31", "2020-03-31"]),
+            "rdq": [pd.Timestamp("2020-04-30"), pd.NaT],
+            "fqtr": [1, 1],
+            "fyearq": [2020, 2020],
+            "atq": [10, 13],
+            "ceqq": [8, 11],
+            "curcdq": ["USD", "CAD"],
+        }
+    )
+
+    with (
+        patch(
+            "tidyfinance.download_wrds.get_wrds_connection", return_value="con"
+        ),
+        patch("tidyfinance.download_wrds.disconnect_connection"),
+        patch("tidyfinance.download_wrds.pd.read_sql", return_value=fundq),
+    ):
+        out = _download_data_wrds_compustat(
+            "compustat_quarterly",
+            "2020-01-01",
+            "2020-12-31",
+            additional_columns=["rdq", "fyearq", "fqtr", "curcdq"],
+        )
+
+    assert list(out.columns) == [
+        "gvkey",
+        "date",
+        "datadate",
+        "atq",
+        "ceqq",
+        "rdq",
+        "fyearq",
+        "fqtr",
+        "curcdq",
+    ]
+    assert list(out["fyearq"]) == [2020, 2020]
+    assert list(out["fqtr"]) == [1, 1]
+    assert list(out["curcdq"]) == ["USD", "CAD"]
+    assert out["rdq"].iloc[0] == pd.Timestamp("2020-04-30")
+
+
 def test_quarterly_data_can_return_non_usd_observations():
     """Test quarterly data can return non-USD observations."""
     fundq = pd.DataFrame(

--- a/tidyfinance/download_wrds.py
+++ b/tidyfinance/download_wrds.py
@@ -1188,9 +1188,11 @@ def _download_data_wrds_compustat(
         if only_usd:
             compustat = compustat[compustat["curcdq"] == "USD"]
 
-        processed_data = compustat.get(
-            ["gvkey", "date", "datadate", "atq", "ceqq"] + extra_quarterly
-        )
+        base_output_cols = ["gvkey", "date", "datadate", "atq", "ceqq"]
+        requested_quarterly = [
+            c for c in (additional_columns or []) if c not in base_output_cols
+        ]
+        processed_data = compustat.get(base_output_cols + requested_quarterly)
 
     return processed_data
 


### PR DESCRIPTION
## Problem

As reported in #68, `_download_data_wrds_compustat` could not return the columns `rdq`, `fyearq`, `fqtr`, or `curcdq` for `compustat_quarterly`, even when explicitly requested via `additional_columns`.

The cause: `extra_quarterly` strips base quarterly columns from the request so they are not duplicated in the SQL `SELECT` (correct), but the final output projection reused that same stripped list. The columns were downloaded and used internally for deduplication, then silently dropped from the result.

## Fix

Build the final quarterly projection from the full `additional_columns` request, deduplicated against the base output columns (`gvkey`, `date`, `datadate`, `atq`, `ceqq`). `extra_quarterly` remains unchanged for building the SQL query.

This mirrors the R package (`download_data_wrds_compustat`), whose final `select()` uses `all_of(additional_columns)` and therefore already handles this correctly.

## Relation to #68

Supersedes the approach in #68, which removed the projection and changed `return processed_data` to `return compustat`. That would have:
- broken the annual branch (the shared `return` would skip the final step that adds `date` and drops the `year`/`at_lag`/`curcd` helper columns),
- changed the default quarterly output schema for all users (always including `rdq`, `fqtr`, `fyearq`, `curcdq`), diverging from the R package and the documented behavior,
- failed the existing test that asserts the exact quarterly column list.

This PR fixes the reported issue while keeping the default output schema stable.

## Tests

- New regression test `test_quarterly_base_columns_can_be_requested` covering `additional_columns=["rdq", "fyearq", "fqtr", "curcdq"]`.
- Full suite passes locally (one pre-existing, network-dependent failure in `test_download_data_column_ordering` is unrelated and also fails on `main` in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6js9uqWx18dfBkJZB85CF

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6js9uqWx18dfBkJZB85CF)_