### PR TITLE
Fix Yahoo Finance exchange-local dates and inclusive ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Fixed (Yahoo Finance dates):** Stock price downloads now use the exchange's local time zone, falling back to UTC when the metadata is missing or empty. This corrects previous-day dates for markets such as Australia and New Zealand. Requests include a two-day buffer and results are filtered to include both `start_date` and `end_date`, matching [r-tidyfinance #305](https://github.com/tidy-finance/r-tidyfinance/pull/305). An end date of today can include the current, still-forming daily bar.
+
 ## v0.1.0
 
 - Development version

--- a/tests/test_download_data_stock_prices.py
+++ b/tests/test_download_data_stock_prices.py
@@ -1,8 +1,10 @@
 """Tests for download_data_stock_prices."""
 
+import datetime as dt
 import os
 import sys
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import polars as pl
 import pytest
@@ -11,6 +13,7 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 )
 
+import tidyfinance as tf  # noqa: E402
 from tidyfinance.download_open_source import (  # noqa: E402
     _download_data_stock_prices,
 )
@@ -90,6 +93,162 @@ def test_downloads_data_replaces_null_and_warns_on_failures():
     assert out["volume"][1] is None
     assert out["adjusted_close"][0] == 11
     assert out["adjusted_close"][1] is None
+
+
+def _chart_body(timestamps, meta):
+    values = list(range(1, len(timestamps) + 1))
+    return {
+        "chart": {
+            "result": [
+                {
+                    "meta": meta,
+                    "timestamp": timestamps,
+                    "indicators": {
+                        "quote": [
+                            {
+                                column: values
+                                for column in (
+                                    "volume",
+                                    "open",
+                                    "low",
+                                    "high",
+                                    "close",
+                                )
+                            }
+                        ],
+                        "adjclose": [{"adjclose": values}],
+                    },
+                }
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "meta, expected_day",
+    [
+        ({"exchangeTimezoneName": "Australia/Sydney"}, 16),
+        ({"exchangeTimezoneName": "Pacific/Auckland"}, 16),
+        ({"exchangeTimezoneName": "America/New_York"}, 15),
+        ({"exchangeTimezoneName": "UTC"}, 15),
+        ({"exchangeTimezoneName": None}, 15),
+        ({"exchangeTimezoneName": ""}, 15),
+        ({}, 15),
+        (None, 15),
+    ],
+)
+def test_dates_use_exchange_timezone_with_utc_fallback(meta, expected_day):
+    # Monday's Sydney open is still Sunday in UTC.
+    body = _chart_body([1584313200], meta)
+    with patch("tidyfinance.download_open_source.requests.get") as get:
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = body
+        out = _download_data_stock_prices("^AXJO", "2020-03-01", "2020-03-31")
+
+    assert out["date"].to_list() == [dt.date(2020, 3, expected_day)]
+    assert out.schema["date"] == pl.Date
+    assert out["close"].to_list() == [1]
+
+
+@pytest.mark.parametrize(
+    "timezone, utc_hour",
+    [
+        ("Australia/Sydney", 23),
+        ("Pacific/Auckland", 21),
+        ("America/New_York", 14),
+        ("UTC", 10),
+    ],
+)
+@pytest.mark.parametrize(
+    "start, end, expected_days",
+    [(16, 18, [16, 17, 18]), (16, 16, [16]), (14, 15, [])],
+)
+def test_inclusive_local_range_and_buffered_request(
+    timezone, utc_hour, start, end, expected_days
+):
+    # Include bars before and after the requested range. Sydney and
+    # Auckland opens fall on the preceding UTC date.
+    timestamps = [
+        int(
+            dt.datetime(
+                2020,
+                3,
+                day - (utc_hour >= 21),
+                utc_hour,
+                tzinfo=dt.timezone.utc,
+            ).timestamp()
+        )
+        for day in [13, 16, 17, 18, 19]
+    ]
+    body = _chart_body(timestamps, {"exchangeTimezoneName": timezone})
+    start_date = dt.date(2020, 3, start)
+    end_date = dt.date(2020, 3, end)
+    with patch("tidyfinance.download_open_source.requests.get") as get:
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = body
+        out = _download_data_stock_prices("TEST", start_date, end_date)
+
+    assert out["date"].to_list() == [
+        dt.date(2020, 3, day) for day in expected_days
+    ]
+    assert out.schema["date"] == pl.Date
+    query = parse_qs(urlparse(get.call_args.args[0]).query)
+    for key, bound in [
+        ("period1", start_date - dt.timedelta(days=2)),
+        ("period2", end_date + dt.timedelta(days=2)),
+    ]:
+        assert int(query[key][0]) == int(
+            dt.datetime.combine(
+                bound, dt.time(), tzinfo=dt.timezone.utc
+            ).timestamp()
+        )
+
+
+def test_exchange_timezone_observes_daylight_saving_changes():
+    # Sydney's 10:00 open is 23:00 UTC in summer, 00:00 UTC in winter.
+    timestamps = [1584313200, 1594771200]
+    body = _chart_body(timestamps, {"exchangeTimezoneName": "Australia/Sydney"})
+    with patch("tidyfinance.download_open_source.requests.get") as get:
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = body
+        out = _download_data_stock_prices("^AXJO", "2020-03-01", "2020-07-31")
+
+    assert out["date"].to_list() == [dt.date(2020, 3, 16), dt.date(2020, 7, 15)]
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_public_download_handles_each_symbols_timezone(backend):
+    def fake_get(url, **kwargs):
+        timezone = "Australia/Sydney" if "^AXJO" in url else "America/New_York"
+        return MagicMock(
+            status_code=200,
+            json=lambda: _chart_body(
+                [1584313200], {"exchangeTimezoneName": timezone}
+            ),
+        )
+
+    previous_backend = tf.get_backend()
+    try:
+        tf.set_backend(backend)
+        with patch(
+            "tidyfinance.download_open_source.requests.get",
+            side_effect=fake_get,
+        ):
+            out = tf.download_data(
+                "Stock Prices",
+                symbols=["^AXJO", "AAPL"],
+                start_date="2020-03-15",
+                end_date="2020-03-16",
+            )
+        if backend == "pandas":
+            out = pl.from_pandas(out).with_columns(pl.col("date").cast(pl.Date))
+        assert out["symbol"].to_list() == ["^AXJO", "AAPL"]
+        assert out["date"].to_list() == [
+            dt.date(2020, 3, 16),
+            dt.date(2020, 3, 15),
+        ]
+    finally:
+        tf.set_backend(previous_backend)
 
 
 if __name__ == "__main__":

--- a/tidyfinance/download.py
+++ b/tidyfinance/download.py
@@ -96,7 +96,9 @@ def download_data(
     pl.DataFrame
         A data frame with processed data, including dates and the
         relevant financial metrics, filtered by the specified date
-        range.
+        range. For 'Stock Prices', dates are trading days in the
+        exchange's local time zone (UTC when Yahoo Finance omits it),
+        and both start_date and end_date are inclusive.
 
     Examples
     --------

--- a/tidyfinance/download_open_source.py
+++ b/tidyfinance/download_open_source.py
@@ -1446,7 +1446,9 @@ def _download_data_stock_prices(
     Download stock data from Yahoo Finance.
 
     Downloads historical stock data from Yahoo Finance for the given
-    symbols and date range.
+    symbols and date range. Dates are trading days in the exchange's
+    local time zone reported by Yahoo Finance (UTC when missing). Both
+    start_date and end_date are inclusive.
 
     Parameters
     ----------
@@ -1488,9 +1490,13 @@ def _download_data_stock_prices(
         start_date, end_date, use_default_range=True
     )
 
-    # Treat the calendar dates as UTC midnight for the Yahoo query.
-    start_timestamp = calendar.timegm(start_date.timetuple())
-    end_timestamp = calendar.timegm(end_date.timetuple())
+    # Buffer the UTC request window to include boundary trading days in
+    # every exchange time zone, then filter on local dates below.
+    request_buffer = dt.timedelta(days=2)
+    start_timestamp = calendar.timegm(
+        (start_date - request_buffer).timetuple()
+    )
+    end_timestamp = calendar.timegm((end_date + request_buffer).timetuple())
 
     all_data = []
 
@@ -1526,10 +1532,18 @@ def _download_data_stock_prices(
                 "adjclose"
             ]
 
-            dates = [
-                dt.datetime.fromtimestamp(ts, dt.timezone.utc).date()
-                for ts in timestamps
-            ]
+            # Daily timestamps mark the exchange-local market open,
+            # which can fall on the preceding calendar day in UTC.
+            meta = raw_data[0].get("meta") or {}
+            exchange_timezone = meta.get("exchangeTimezoneName") or "UTC"
+            dates = (
+                pl.from_epoch(
+                    pl.Series(timestamps, dtype=pl.Int64), time_unit="s"
+                )
+                .dt.replace_time_zone("UTC")
+                .dt.convert_time_zone(exchange_timezone)
+                .dt.date()
+            )
             df_symbol = pl.DataFrame(
                 {
                     "symbol": [symbol] * len(dates),
@@ -1543,7 +1557,11 @@ def _download_data_stock_prices(
                 }
             )
 
-            all_data.append(df_symbol)
+            all_data.append(
+                df_symbol.filter(
+                    pl.col("date").is_between(start_date, end_date)
+                )
+            )
 
         else:
             warnings.warn(


### PR DESCRIPTION
Yahoo stock-price downloads derived trading dates in UTC, dating Sydney and Auckland bars one day early, and delegated date boundaries entirely to Yahoo. This ports the logic from https://github.com/tidy-finance/r-tidyfinance/pull/305: convert timestamps using each symbol's `exchangeTimezoneName` (UTC when absent, null, or empty), request two extra days on each side, then filter exchange-local dates inclusively.

For example, the Sydney market open at timestamp `1584313200` now belongs to Monday 2020-03-16 instead of Sunday 2020-03-15, and a single-day request for 2020-03-16 retains that bar. Conversion uses Polars' time-zone support without adding dependencies. Public API documentation and the changelog describe the behavior; an end date of today can include the still-forming daily bar.

Validation:
- All 704 tests pass (`python -m pytest tests -q`), including the existing live Yahoo test.
- 25 stock-price tests cover exchange time zones, UTC fallbacks, daylight saving, inclusive bounds, request buffering, single-day and weekend-only ranges, and mixed exchanges through both public backends. Before the fix, 15 regression cases failed.
- Ruff checks and `git diff --check` pass.
